### PR TITLE
feat(dashboard): Add dedicated EPCI dashboard

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,14 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  # Dans app/controllers/application_controller.rb, ajoutez cette méthode:
+  def dashboard_router
+    if current_user.territory_type == 'epci'
+      redirect_to epci_dashboard_path
+    else
+      redirect_to dashboard_path
+    end
+  end
+
 end

--- a/app/controllers/epci_dashboard_controller.rb
+++ b/app/controllers/epci_dashboard_controller.rb
@@ -1,0 +1,40 @@
+class EpciDashboardController < ApplicationController
+  include UserAuthorization
+  before_action :check_epci_user
+
+  def index
+    @epci_code = current_user.territory_code
+    @epci_name = current_user.territory_name
+
+    # Récupérer les données EPCI
+    @epci_communes_data = Api::EpciCommunesService.get_children_by_communes(@epci_code)
+    @epci_children_data = Api::PopulationService.get_epci_children_data(@epci_code)
+    @epci_revenue_data = Api::RevenueService.get_median_revenues_epci(@epci_code)
+    @epci_family_data = Api::FamilyService.get_epci_families(@epci_code)
+    @epci_schooling_data = Api::SchoolingService.get_epci_schooling(@epci_code)
+    @epci_childcare_data = Api::ChildcareService.get_coverage_by_epci(@epci_code)
+
+    # Préparation des données pour les graphiques
+    prepare_communes_chart_data if @epci_communes_data.present?
+  end
+
+  private
+
+  def check_epci_user
+    unless current_user.territory_type == 'epci' && current_user.territory_code.present?
+      redirect_to root_path, alert: "Ce dashboard est réservé aux utilisateurs EPCI."
+    end
+  end
+
+  def prepare_communes_chart_data
+    communes = @epci_communes_data["communes"].sort_by { |c| -c["under_3_rate"] }
+
+    @communes_under3_data = {
+      commune_names: communes.map { |c| c["name"] },
+      under3_rates: communes.map { |c| c["under_3_rate"] },
+      children_under3_counts: communes.map { |c| c["children_under_3"].round },
+      commune_codes: communes.map { |c| c["code"] },
+      commune_populations: communes.map { |c| c["total_population"].round }
+    }
+  end
+end

--- a/app/helpers/epci_dashboard_helper.rb
+++ b/app/helpers/epci_dashboard_helper.rb
@@ -1,0 +1,2 @@
+module EpciDashboardHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -15,9 +15,13 @@ window.Chart = ChartModule.Chart
 window.ChartDataLabels = ChartDataLabels
 Chart.register(ChartDataLabels)
 
+// Commune Dashboard
 import "charts/historique_chart"
 import "charts/economic_charts"
 import "charts/births_chart"
 import "charts/domestic_violence_chart"
 import "charts/family_employment_chart"
 import "charts/age_pyramid_chart"
+
+// EPCI Dashboard
+import "charts/epci_communes_chart"

--- a/app/javascript/charts/epci_communes_chart.js
+++ b/app/javascript/charts/epci_communes_chart.js
@@ -1,0 +1,112 @@
+// app/javascript/charts/epci_communes_chart.js
+document.addEventListener("turbo:load", () => {
+  const chartElement = document.getElementById("epci-communes-chart");
+  const dataElement = document.getElementById("communes-children-data");
+
+  if (!chartElement || !dataElement || typeof Chart === "undefined") {
+    console.warn("Chart.js ou données EPCI manquantes");
+    return;
+  }
+
+  try {
+    const chartData = JSON.parse(dataElement.textContent);
+
+    // Créer un dégradé de couleurs basé sur les valeurs
+    const backgroundColors = chartData.under3_rates.map(rate => {
+      // Rouge pour les valeurs hautes, jaune pour les moyennes, vert pour les basses
+      if (rate > 4.5) return 'rgba(220, 38, 38, 0.7)'; // Rouge
+      if (rate > 3.5) return 'rgba(245, 158, 11, 0.7)'; // Orange
+      if (rate > 2.5) return 'rgba(252, 211, 77, 0.7)'; // Jaune
+      return 'rgba(16, 185, 129, 0.7)'; // Vert
+    });
+
+    // Créer des tooltip labels personnalisés avec le nombre d'enfants
+    const tooltipLabels = chartData.commune_names.map((name, index) => {
+      const pop = chartData.commune_populations[index].toLocaleString('fr-FR');
+      const childrenCount = chartData.children_under3_counts[index].toLocaleString('fr-FR');
+      return `${name} - Population: ${pop} - Enfants <3 ans: ${childrenCount}`;
+    });
+
+    new Chart(chartElement, {
+      type: 'bar',
+      data: {
+        labels: chartData.commune_names,
+        datasets: [{
+          label: 'Taux d\'enfants -3 ans (%)',
+          data: chartData.under3_rates,
+          backgroundColor: backgroundColors,
+          borderColor: backgroundColors.map(color => color.replace('0.7', '1')),
+          borderWidth: 1
+        }]
+      },
+      options: {
+        indexAxis: 'y', // Barres horizontales
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            display: false
+          },
+          tooltip: {
+            callbacks: {
+              title: function(tooltipItems) {
+                const idx = tooltipItems[0].dataIndex;
+                return tooltipLabels[idx];
+              },
+              label: function(context) {
+                return `Taux: ${context.raw.toFixed(2)}%`;
+              },
+              afterLabel: function(context) {
+                const idx = context.dataIndex;
+                const childrenCount = chartData.children_under3_counts[idx];
+                return `Nombre d'enfants <3 ans: ${childrenCount.toLocaleString('fr-FR')}`;
+              }
+            }
+          },
+          datalabels: {
+            color: '#000',
+            font: {
+              weight: 'bold',
+              size: 10
+            },
+            formatter: (value, context) => {
+              const idx = context.dataIndex;
+              const childrenCount = chartData.children_under3_counts[idx];
+              return `${value.toFixed(2)}% (${childrenCount})`;
+            },
+            anchor: 'end',
+            align: 'end',
+            offset: 4
+          }
+        },
+        scales: {
+          x: {
+            beginAtZero: true,
+            title: {
+              display: true,
+              text: 'Pourcentage d\'enfants de moins de 3 ans (%)'
+            },
+            grid: {
+              display: true
+            }
+          },
+          y: {
+            grid: {
+              display: false
+            },
+            ticks: {
+              font: {
+                size: 11
+              }
+            }
+          }
+        }
+      },
+      plugins: [ChartDataLabels]
+    });
+
+    console.log("✅ Graphique EPCI enfants -3 ans créé avec succès");
+  } catch (e) {
+    console.error("Erreur graphique EPCI enfants:", e);
+  }
+});

--- a/app/services/api/epci_communes_service.rb
+++ b/app/services/api/epci_communes_service.rb
@@ -1,0 +1,7 @@
+module Api
+  class EpciCommunesService
+    def self.get_children_by_communes(epci_code)
+      ApiClientService.instance.get("/epci/population/children/#{epci_code}/communes")
+    end
+  end
+end

--- a/app/views/epci_dashboard/_communes_children.html.erb
+++ b/app/views/epci_dashboard/_communes_children.html.erb
@@ -1,0 +1,24 @@
+<!-- app/views/epci_dashboard/_communes_children.html.erb -->
+<div class="bg-white shadow rounded-lg p-6 mb-6">
+  <h2 class="text-lg font-medium text-gray-900 mb-4">Taux d'enfants par commune</h2>
+
+  <div class="mb-6">
+    <h3 class="text-sm font-medium text-gray-700 mb-4">Enfants de moins de 3 ans (% de la population)</h3>
+    <div class="h-[600px] overflow-y-auto pr-4">
+      <canvas id="epci-communes-chart"></canvas>
+    </div>
+  </div>
+
+  <div class="mt-6 bg-gray-50 p-4 rounded-md">
+    <h3 class="text-sm font-medium text-gray-700 mb-2">À propos de ces données</h3>
+    <p class="text-sm text-gray-600">
+      Ce graphique présente le pourcentage d'enfants de moins de 3 ans dans chaque commune de votre EPCI,
+      classées par ordre décroissant. Les communes avec des taux élevés peuvent nécessiter une attention
+      particulière concernant les structures d'accueil de la petite enfance.
+    </p>
+  </div>
+</div>
+
+<script type="application/json" id="communes-children-data">
+  <%= raw(@communes_under3_data.to_json) %>
+</script>

--- a/app/views/epci_dashboard/index.html.erb
+++ b/app/views/epci_dashboard/index.html.erb
@@ -1,0 +1,15 @@
+<div class="py-6">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="text-2xl font-semibold text-gray-900">Dashboard EPCI: <%= @epci_name %></h1>
+      <span class="px-3 py-1 bg-indigo-100 text-indigo-800 rounded-full text-sm font-medium">
+        Code EPCI: <%= @epci_code %>
+      </span>
+    </div>
+
+
+    <%= render "epci_dashboard/communes_children" %>
+    <%# <%= render "epci_dashboard/communes_heatmap" %> %>
+
+  </div>
+</div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -14,10 +14,16 @@
             Accueil
           </a>
 
-          <% if user_signed_in? && current_user.territory_code.present? %>
-            <a href="<%= dashboard_path %>" class="<%= current_page?(dashboard_path) ? 'border-indigo-500 text-gray-900' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700' %> inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">
-              Dashboard
-            </a>
+          <% if user_signed_in? %>
+            <% if current_user.territory_type == 'epci' %>
+              <a href="<%= epci_dashboard_path %>" class="<%= current_page?(epci_dashboard_path) ? 'border-indigo-500 text-gray-900' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700' %> inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">
+                Dashboard EPCI
+              </a>
+            <% elsif current_user.territory_code.present? %>
+              <a href="<%= dashboard_path %>" class="<%= current_page?(dashboard_path) ? 'border-indigo-500 text-gray-900' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700' %> inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">
+                Dashboard Commune
+              </a>
+            <% end %>
           <% end %>
 
           <a href="#" class="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Fonctionnalités</a>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -11,11 +11,15 @@ pin "chartjs-plugin-datalabels", to: "https://cdn.jsdelivr.net/npm/chartjs-plugi
 # ✅ AlpineJS via UMD (ne pas utiliser "default")
 pin "alpinejs", to: "https://cdn.jsdelivr.net/npm/alpinejs@3.14.9/dist/module.esm.js"
 
+# Commune Dashboard
 pin "charts/historique_chart", to: "charts/historique_chart.js"
 pin "charts/economic_charts", to: "charts/economic_charts.js"
 pin "charts/births_chart", to: "charts/births_chart.js"
 pin "charts/domestic_violence_chart", to: "charts/domestic_violence_chart.js"
 pin "charts/family_employment_chart", to: "charts/family_employment_chart.js"
 pin "charts/age_pyramid_chart", to: "charts/age_pyramid_chart.js"
+
+# EPCI Dashboard
+pin "charts/epci_communes_chart", to: "charts/epci_communes_chart.js"
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "epci_dashboard/index"
   devise_for :users, controllers: {
     sessions: 'users/sessions',
     registrations: 'users/registrations'
@@ -13,14 +14,15 @@ Rails.application.routes.draw do
   # Route pour l'autocomplétion des EPCI
   get 'epcis/autocomplete', to: 'epcis#autocomplete'
 
-
-  # Routes pour le dashboard
+  # Routes pour les dashboards
   get 'dashboard', to: 'dashboard#index'
+  get 'epci_dashboard', to: 'epci_dashboard#index'
 
-  # Rediriger les utilisateurs connectés vers leur dashboard
+  # Redirection conditionnelle selon le type d'utilisateur
   authenticated :user do
-    root 'dashboard#index', as: :authenticated_root
+    root to: "application#dashboard_router", as: :authenticated_root
   end
 
+  # Route par défaut
   root "home#index"
 end

--- a/test/controllers/epci_dashboard_controller_test.rb
+++ b/test/controllers/epci_dashboard_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class EpciDashboardControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get epci_dashboard_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Implement a separate dashboard for EPCI users with specific visualizations:
- Create EpciDashboardController with dedicated views
- Add horizontal bar chart for children under 3 years by commune
- Configure routing to direct users to appropriate dashboard based on territory type
- Add EPCI-specific components for displaying childcare data

This dashboard provides EPCI administrators with territory-wide insights across all member communes, focusing on early childhood metrics