### PR TITLE
feat: add dual-map visualization for under-3 children in EPCI dashboard

### DIFF
--- a/app/controllers/api/geometries_controller.rb
+++ b/app/controllers/api/geometries_controller.rb
@@ -1,0 +1,48 @@
+module Api
+  class GeometriesController < ApplicationController
+    include UserAuthorization
+
+    def communes_by_epci
+      # Vérifier que l'utilisateur a accès à cet EPCI
+      unless current_user.super_admin? || current_user.territory_code == params[:epci_code]
+        return render json: { error: "Unauthorized" }, status: :unauthorized
+      end
+
+      # Récupérer les géométries des communes de l'EPCI
+      geometries = CommuneGeometry.where(epci: params[:epci_code])
+
+      # Récupérer les données démographiques
+      epci_communes_data = Api::EpciCommunesService.get_children_by_communes(params[:epci_code])
+
+      # Préparer le GeoJSON
+      features = []
+
+      geometries.each do |geometry|
+        # Trouver les données démographiques correspondantes
+        commune_data = epci_communes_data["communes"].find { |c| c["code"] == geometry.code_insee }
+        next unless commune_data && geometry.geojson.present?
+
+        feature = {
+          type: "Feature",
+          properties: {
+            code: geometry.code_insee,
+            name: geometry.nom,
+            under3_rate: commune_data["under_3_rate"],
+            children_under3: commune_data["children_under_3"].round,
+            population: commune_data["total_population"].round
+          },
+          geometry: JSON.parse(geometry.geojson)
+        }
+
+        features << feature
+      end
+
+      geojson = {
+        type: "FeatureCollection",
+        features: features
+      }
+
+      render json: geojson
+    end
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -8,6 +8,10 @@ import * as Alpine from "alpinejs"
 window.Alpine = Alpine
 Alpine.start()
 
+// Ajouter l'import pour Leaflet
+import * as L from "leaflet"
+window.L = L
+
 // ✅ Chart.js UMD (pas de default)
 import * as ChartModule from "chart.js"
 import * as ChartDataLabels from "chartjs-plugin-datalabels"

--- a/app/models/commune_geometry.rb
+++ b/app/models/commune_geometry.rb
@@ -1,0 +1,6 @@
+class CommuneGeometry < ApplicationRecord
+  validates :code_insee, presence: true, uniqueness: true
+
+  # Relation avec Territory
+  belongs_to :territory, foreign_key: :code_insee, primary_key: :codgeo, optional: true
+end

--- a/app/views/epci_dashboard/_communes_children.html.erb
+++ b/app/views/epci_dashboard/_communes_children.html.erb
@@ -1,24 +1,185 @@
-<!-- app/views/epci_dashboard/_communes_children.html.erb -->
 <div class="bg-white shadow rounded-lg p-6 mb-6">
-  <h2 class="text-lg font-medium text-gray-900 mb-4">Taux d'enfants par commune</h2>
+  <h2 class="text-lg font-medium text-gray-900 mb-4">Les enfants</h2>
+  <h2 class="text-lg font-medium text-gray-900 mb-4">Répartition des enfants de moins de 3 ans par commune</h2>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <!-- 🟩 Carte des effectifs -->
+    <div>
+      <h3 class="text-sm font-medium text-gray-700 mb-2">Carte des effectifs par commune</h3>
+      <div id="communes-map-effectifs" class="h-[500px] w-full border border-gray-200 rounded-md"></div>
+      <div id="effectif-legend" class="mt-3"></div>
+    </div>
 
-  <div class="mb-6">
-    <h3 class="text-sm font-medium text-gray-700 mb-4">Enfants de moins de 3 ans (% de la population)</h3>
-    <div class="h-[600px] overflow-y-auto pr-4">
-      <canvas id="epci-communes-chart"></canvas>
+    <!-- 🟦 Carte des taux -->
+    <div>
+      <h3 class="text-sm font-medium text-gray-700 mb-2">Carte des taux par commune</h3>
+      <div id="communes-map" class="h-[500px] w-full border border-gray-200 rounded-md"></div>
+      <div id="taux-legend" class="mt-3"></div>
     </div>
   </div>
 
   <div class="mt-6 bg-gray-50 p-4 rounded-md">
     <h3 class="text-sm font-medium text-gray-700 mb-2">À propos de ces données</h3>
     <p class="text-sm text-gray-600">
-      Ce graphique présente le pourcentage d'enfants de moins de 3 ans dans chaque commune de votre EPCI,
-      classées par ordre décroissant. Les communes avec des taux élevés peuvent nécessiter une attention
-      particulière concernant les structures d'accueil de la petite enfance.
+      Cette visualisation présente à gauche les effectifs d'enfants de moins de 3 ans par commune,
+      et à droite leur pourcentage dans la population totale.
+      Les seuils de couleur ont été déterminés automatiquement à l’aide de la méthode de discrétisation statistique de Jenks (Jenks Natural Breaks),
+      afin de mieux faire ressortir les variations significatives entre les communes.
     </p>
   </div>
 </div>
 
-<script type="application/json" id="communes-children-data">
-  <%= raw(@communes_under3_data.to_json) %>
+<!-- Données JSON -->
+<script type="application/json" id="communes-geojson">
+  <%= raw(@communes_geojson) %>
+</script>
+
+<script>
+  document.addEventListener("turbo:load", function () {
+    initializeMapEffectifs();
+    initializeMapTaux();
+  });
+
+  function renderLegend(breaks, containerId, colors, unit = "") {
+    const container = document.getElementById(containerId);
+    container.innerHTML = "";
+
+    const legend = document.createElement("div");
+    legend.className = "flex flex-wrap items-center justify-center space-x-4 text-xs text-gray-700";
+
+    const format = val => {
+      if (unit === "%") return val.toFixed(2);
+      return Math.round(val);
+    };
+
+    const labels = [
+      `≤ ${format(breaks[1] - 0.01)}${unit}`,
+      `${format(breaks[1])} – ${format(breaks[2] - 0.01)}${unit}`,
+      `${format(breaks[2])} – ${format(breaks[3] - 0.01)}${unit}`,
+      `≥ ${format(breaks[3])}${unit}`
+    ];
+
+    for (let i = 0; i < 4; i++) {
+      const item = document.createElement("div");
+      item.className = "flex items-center";
+
+      const colorBox = document.createElement("div");
+      colorBox.className = "w-4 h-4 rounded mr-2";
+      colorBox.style.backgroundColor = colors[i];
+
+      const label = document.createElement("span");
+      label.textContent = labels[i];
+
+      item.appendChild(colorBox);
+      item.appendChild(label);
+      legend.appendChild(item);
+    }
+
+    container.appendChild(legend);
+  }
+
+  function initializeMapEffectifs() {
+    const mapElement = document.getElementById("communes-map-effectifs");
+    const geojsonElement = document.getElementById("communes-geojson");
+    if (!mapElement || !geojsonElement || typeof L === "undefined" || typeof ss === "undefined") return;
+
+    const geojsonData = JSON.parse(geojsonElement.textContent);
+    const values = geojsonData.features.map(f => f.properties.children_under3).sort((a, b) => a - b);
+    const clusters = ss.ckmeans(values, 4);
+    const breaks = clusters.map(c => c[0]);
+    breaks.push(clusters[clusters.length - 1].slice(-1)[0]);
+
+    const colors = ["#6baed6", "#fed976", "#fd8d3c", "#e31a1c"];
+
+    function getColor(count) {
+      return count > breaks[3] ? colors[3] :
+             count > breaks[2] ? colors[2] :
+             count > breaks[1] ? colors[1] :
+                                 colors[0];
+    }
+
+    function style(feature) {
+      return {
+        fillColor: getColor(feature.properties.children_under3),
+        weight: 1,
+        opacity: 1,
+        color: "white",
+        fillOpacity: 0.7
+      };
+    }
+
+    function onEachFeature(feature, layer) {
+      const popup = `
+        <div class="text-sm">
+          <strong>${feature.properties.name}</strong><br>
+          Enfants < 3 ans : ${feature.properties.children_under3}<br>
+          Taux : ${feature.properties.under3_rate.toFixed(2)}%<br>
+          Population : ${feature.properties.population.toLocaleString('fr-FR')}
+        </div>
+      `;
+      layer.bindPopup(popup);
+    }
+
+    const map = L.map(mapElement);
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      attribution: "© OpenStreetMap contributors",
+    }).addTo(map);
+
+    const layer = L.geoJSON(geojsonData, { style, onEachFeature }).addTo(map);
+    map.fitBounds(layer.getBounds());
+
+    renderLegend(breaks, "effectif-legend", colors);
+  }
+
+  function initializeMapTaux() {
+    const mapElement = document.getElementById("communes-map");
+    const geojsonElement = document.getElementById("communes-geojson");
+    if (!mapElement || !geojsonElement || typeof L === "undefined" || typeof ss === "undefined") return;
+
+    const geojsonData = JSON.parse(geojsonElement.textContent);
+    const values = geojsonData.features.map(f => f.properties.under3_rate).sort((a, b) => a - b);
+    const clusters = ss.ckmeans(values, 4);
+    const breaks = clusters.map(c => c[0]);
+    breaks.push(clusters[clusters.length - 1].slice(-1)[0]);
+
+    const colors = ["#6baed6", "#fed976", "#fd8d3c", "#e31a1c"];
+
+    function getColor(rate) {
+      return rate > breaks[3] ? colors[3] :
+             rate > breaks[2] ? colors[2] :
+             rate > breaks[1] ? colors[1] :
+                                colors[0];
+    }
+
+    function style(feature) {
+      return {
+        fillColor: getColor(feature.properties.under3_rate),
+        weight: 1,
+        opacity: 1,
+        color: "white",
+        fillOpacity: 0.7
+      };
+    }
+
+    function onEachFeature(feature, layer) {
+      const popup = `
+        <div class="text-sm">
+          <strong>${feature.properties.name}</strong><br>
+          Taux d'enfants < 3 ans : ${feature.properties.under3_rate.toFixed(2)}%<br>
+          Enfants : ${feature.properties.children_under3}<br>
+          Population : ${feature.properties.population.toLocaleString('fr-FR')}
+        </div>
+      `;
+      layer.bindPopup(popup);
+    }
+
+    const map = L.map(mapElement);
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      attribution: "© OpenStreetMap contributors",
+    }).addTo(map);
+
+    const layer = L.geoJSON(geojsonData, { style, onEachFeature }).addTo(map);
+    map.fitBounds(layer.getBounds());
+
+    renderLegend(breaks, "taux-legend", colors, " %");
+  }
 </script>

--- a/app/views/epci_dashboard/index.html.erb
+++ b/app/views/epci_dashboard/index.html.erb
@@ -6,10 +6,6 @@
         Code EPCI: <%= @epci_code %>
       </span>
     </div>
-
-
     <%= render "epci_dashboard/communes_children" %>
-    <%# <%= render "epci_dashboard/communes_heatmap" %> %>
-
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,11 @@
 
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
+    <script src="https://unpkg.com/simple-statistics@7.7.2/dist/simple-statistics.min.js"></script>
     <%= javascript_importmap_tags %>
+
   </head>
 
   <body class="bg-gray-100 flex flex-col min-h-screen">

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -21,5 +21,7 @@ pin "charts/age_pyramid_chart", to: "charts/age_pyramid_chart.js"
 
 # EPCI Dashboard
 pin "charts/epci_communes_chart", to: "charts/epci_communes_chart.js"
-
+# config/importmap.rb
+pin "leaflet", to: "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+pin "leaflet-css", to: "https://unpkg.com/leaflet@1.9.4/dist/leaflet.css", preload: true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
     root to: "application#dashboard_router", as: :authenticated_root
   end
 
+  get 'api/communes_geometries/:epci_code', to: 'api/geometries#communes_by_epci'
+
   # Route par défaut
   root "home#index"
 end

--- a/db/migrate/20250408123510_create_commune_geometries.rb
+++ b/db/migrate/20250408123510_create_commune_geometries.rb
@@ -1,0 +1,15 @@
+class CreateCommuneGeometries < ActiveRecord::Migration[8.0]
+  def change
+    create_table :commune_geometries do |t|
+      t.string :code_insee, null: false
+      t.string :nom
+      t.string :epci
+      t.text :geojson
+
+      t.timestamps
+
+      t.index :code_insee, unique: true
+      t.index :epci
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_06_143345) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_08_123510) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "unaccent"
+
+  create_table "commune_geometries", force: :cascade do |t|
+    t.string "code_insee", null: false
+    t.string "nom"
+    t.string "epci"
+    t.text "geojson"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code_insee"], name: "index_commune_geometries_on_code_insee", unique: true
+    t.index ["epci"], name: "index_commune_geometries_on_epci"
+  end
 
   create_table "epcis", force: :cascade do |t|
     t.string "epci", null: false

--- a/lib/tasks/import_geometries.rake
+++ b/lib/tasks/import_geometries.rake
@@ -1,0 +1,53 @@
+# lib/tasks/import_geometries.rake
+namespace :import do
+  desc "Import commune geometries from GeoJSON file"
+  task commune_geometries: :environment do
+    require 'json'
+
+    puts "Starting import of commune geometries..."
+
+    file_path = Rails.root.join('db', 'data', 'communes.geojson')
+    geojson = JSON.parse(File.read(file_path))
+
+    # Compteurs pour le reporting
+    total = geojson['features'].count
+    imported = 0
+    skipped = 0
+
+    geojson['features'].each do |feature|
+      code_insee = feature['properties']['com_code']&.first
+      nom = feature['properties']['com_name']&.first || feature['properties']['com_name']
+
+      if code_insee.blank?
+        skipped += 1
+        puts "\nSkipped (no code_insee): #{feature['properties'].inspect}"
+        next
+      end
+
+      territory = Territory.find_by(codgeo: code_insee)
+      epci = territory&.epci
+
+      geometry = CommuneGeometry.find_or_initialize_by(code_insee: code_insee)
+
+      if geometry.new_record? || geometry.geojson.nil?
+        geometry.nom = nom
+        geometry.epci = epci
+        geometry.geojson = feature['geometry'].to_json
+
+        if geometry.save
+          imported += 1
+          print "." if imported % 100 == 0
+        else
+          skipped += 1
+          puts "\nSkipped: #{code_insee} - #{geometry.errors.full_messages.join(', ')}"
+        end
+      else
+        skipped += 1
+      end
+    end
+
+
+    puts "\nImport completed!"
+    puts "Total: #{total}, Imported: #{imported}, Skipped: #{skipped}"
+  end
+end


### PR DESCRIPTION
- Added two side-by-side Leaflet maps: one for absolute counts, one for percentage of children under 3
- Used Jenks Natural Breaks (ckmeans) for dynamic data classification in both maps
- Implemented dynamic color legends based on computed thresholds
- Applied blue-yellow-orange-red color gradient for clearer intensity perception
- Improved popup information for each commune with population, count and rate
- Updated 'About these data' section to mention the Jenks method