### PR TITLE
feat: Add commune dashboard access from EPCI dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,9 +3,19 @@ class DashboardController < ApplicationController
   before_action :check_user_territory
 
   def index
-    @territory_code = current_user.territory_code
-    @territory_name = current_user.territory_name
-
+    # Déterminer le code territoire à utiliser
+    if params[:commune_code].present?
+      # Si un code commune est fourni en paramètre
+      @territory_code = params[:commune_code]
+      territory = Territory.find_by(codgeo: @territory_code)
+      @territory_name = territory&.libgeo || "Commune inconnue"
+      @is_commune_access_from_epci = true
+    else
+      # Utiliser le territoire de l'utilisateur
+      @territory_code = current_user.territory_code
+      @territory_name = current_user.territory_name
+      @is_commune_access_from_epci = false
+    end
 
     # Récupérer les données de base pour la commune
     @population_data = Api::PopulationService.get_commune_data(@territory_code)
@@ -35,44 +45,43 @@ class DashboardController < ApplicationController
     @france_family_employment_under3_data = Api::FamilyEmploymentService.get_under3_france
     @france_family_employment_3to5_data = Api::FamilyEmploymentService.get_3to5_france
 
-    # Si l'utilisateur a une commune, récupérer les données EPCI, département et région associées
-    if current_user.territory_type == 'commune'
-      territory = Territory.find_by(codgeo: @territory_code)
-      if territory
-        if territory.epci.present?
-          @epci_children_data = Api::PopulationService.get_epci_children_data(territory.epci)
-          @epci_revenue_data = Api::RevenueService.get_median_revenues_epci(territory.epci)
-          @epci_schooling_data = Api::SchoolingService.get_epci_schooling(territory.epci)
-          @epci_employment_data = Api::EmploymentService.get_epci_employment(territory.epci)
-          @epci_childcare_data = Api::ChildcareService.get_coverage_by_epci(territory.epci) if territory&.epci.present?
-          @epci_family_data = Api::FamilyService.get_epci_families(territory.epci)
-          @epci_family_employment_under3_data = Api::FamilyEmploymentService.get_under3_epci(territory.epci)
-          @epci_family_employment_3to5_data = Api::FamilyEmploymentService.get_3to5_epci(territory.epci)
-        end
+    # Récupérer les données EPCI, département et région pour la commune
+    # IMPORTANT: Utiliser toujours le territoire de la commune (@territory_code) et non celui de l'utilisateur
+    territory = Territory.find_by(codgeo: @territory_code)
+    if territory
+      if territory.epci.present?
+        @epci_children_data = Api::PopulationService.get_epci_children_data(territory.epci)
+        @epci_revenue_data = Api::RevenueService.get_median_revenues_epci(territory.epci)
+        @epci_schooling_data = Api::SchoolingService.get_epci_schooling(territory.epci)
+        @epci_employment_data = Api::EmploymentService.get_epci_employment(territory.epci)
+        @epci_childcare_data = Api::ChildcareService.get_coverage_by_epci(territory.epci)
+        @epci_family_data = Api::FamilyService.get_epci_families(territory.epci)
+        @epci_family_employment_under3_data = Api::FamilyEmploymentService.get_under3_epci(territory.epci)
+        @epci_family_employment_3to5_data = Api::FamilyEmploymentService.get_3to5_epci(territory.epci)
+      end
 
-        if territory.dep.present?
-          @department_children_data = Api::PopulationService.get_department_children_data(territory.dep)
-          @department_revenue_data = Api::RevenueService.get_median_revenues_department(territory.dep)
-          @department_schooling_data = Api::SchoolingService.get_department_schooling(territory.dep)
-          @department_employment_data = Api::EmploymentService.get_department_employment(territory.dep)
-          @department_safety_data = Api::PublicSafetyService.get_department_safety(territory.dep)
-          @department_childcare_data = Api::ChildcareService.get_coverage_by_department(territory.dep) if territory&.dep.present?
-          @department_family_data = Api::FamilyService.get_department_families(territory.dep)
-          @department_family_employment_under3_data = Api::FamilyEmploymentService.get_under3_department(territory.dep)
-          @department_family_employment_3to5_data = Api::FamilyEmploymentService.get_3to5_department(territory.dep)
-        end
+      if territory.dep.present?
+        @department_children_data = Api::PopulationService.get_department_children_data(territory.dep)
+        @department_revenue_data = Api::RevenueService.get_median_revenues_department(territory.dep)
+        @department_schooling_data = Api::SchoolingService.get_department_schooling(territory.dep)
+        @department_employment_data = Api::EmploymentService.get_department_employment(territory.dep)
+        @department_safety_data = Api::PublicSafetyService.get_department_safety(territory.dep)
+        @department_childcare_data = Api::ChildcareService.get_coverage_by_department(territory.dep)
+        @department_family_data = Api::FamilyService.get_department_families(territory.dep)
+        @department_family_employment_under3_data = Api::FamilyEmploymentService.get_under3_department(territory.dep)
+        @department_family_employment_3to5_data = Api::FamilyEmploymentService.get_3to5_department(territory.dep)
+      end
 
-        if territory.reg.present?
-          @region_children_data = Api::PopulationService.get_region_children_data(territory.reg)
-          @region_revenue_data = Api::RevenueService.get_median_revenues_region(territory.reg)
-          @region_schooling_data = Api::SchoolingService.get_region_schooling(territory.reg)
-          @region_employment_data = Api::EmploymentService.get_region_employment(territory.reg)
-          @region_safety_data = Api::PublicSafetyService.get_region_safety(territory.reg)
-          @region_childcare_data = Api::ChildcareService.get_coverage_by_region(territory.reg) if territory&.reg.present?
-          @region_family_data = Api::FamilyService.get_region_families(territory.reg)
-          @region_family_employment_under3_data = Api::FamilyEmploymentService.get_under3_region(territory.reg)
-          @region_family_employment_3to5_data = Api::FamilyEmploymentService.get_3to5_region(territory.reg)
-        end
+      if territory.reg.present?
+        @region_children_data = Api::PopulationService.get_region_children_data(territory.reg)
+        @region_revenue_data = Api::RevenueService.get_median_revenues_region(territory.reg)
+        @region_schooling_data = Api::SchoolingService.get_region_schooling(territory.reg)
+        @region_employment_data = Api::EmploymentService.get_region_employment(territory.reg)
+        @region_safety_data = Api::PublicSafetyService.get_region_safety(territory.reg)
+        @region_childcare_data = Api::ChildcareService.get_coverage_by_region(territory.reg)
+        @region_family_data = Api::FamilyService.get_region_families(territory.reg)
+        @region_family_employment_under3_data = Api::FamilyEmploymentService.get_under3_region(territory.reg)
+        @region_family_employment_3to5_data = Api::FamilyEmploymentService.get_3to5_region(territory.reg)
       end
     end
   end
@@ -80,16 +89,44 @@ class DashboardController < ApplicationController
   private
 
   def check_user_territory
-    # Si l'utilisateur n'a pas de territoire associé
+    # Si un paramètre commune_code est fourni, vérifier les autorisations spécifiques
+    if params[:commune_code].present?
+      unless user_can_access_commune?(params[:commune_code])
+        redirect_to root_path, alert: "Vous n'avez pas l'autorisation d'accéder à cette commune."
+      end
+      return # Sortir de la méthode si on a validé l'accès via commune_code
+    end
+
+    # Vérification standard pour les utilisateurs sans paramètre commune_code
     unless current_user.territory_code.present?
-      # Si c'est un super_admin, rediriger vers la gestion des utilisateurs
       if current_user.super_admin?
         redirect_to admin_users_path, notice: "En tant que Super Admin, vous avez été redirigé vers la gestion des utilisateurs."
       else
-        # Pour un utilisateur normal sans territoire (cas qui ne devrait pas se produire selon vos règles)
         redirect_to root_path, alert: "Vous n'avez pas de territoire associé à votre compte. Veuillez contacter un administrateur."
       end
     end
+  end
+
+  def user_can_access_commune?(commune_code)
+    # Vérifier que la commune existe
+    territory = Territory.find_by(codgeo: commune_code)
+    return false unless territory
+
+    # Les super_admin peuvent accéder à toutes les communes
+    return true if current_user.super_admin?
+
+    # Si l'utilisateur est de type EPCI, vérifier que la commune appartient à son EPCI
+    if current_user.territory_type == 'epci'
+      return territory.epci == current_user.territory_code
+    end
+
+    # Si l'utilisateur est de type commune, il peut accéder à sa propre commune
+    if current_user.territory_type == 'commune'
+      return commune_code == current_user.territory_code
+    end
+
+    # Pour les autres cas, refuser l'accès
+    false
   end
 
   def prepare_age_pyramid_data(population_data)
@@ -124,5 +161,4 @@ class DashboardController < ApplicationController
 
     result
   end
-
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,8 +1,20 @@
-<!-- app/views/dashboard/index.html.erb -->
 <div class="py-6">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-semibold text-gray-900">Dashboard de <%= @territory_name %></h1>
+      <div>
+        <h1 class="text-2xl font-semibold text-gray-900">Dashboard de <%= @territory_name %></h1>
+        <% if @is_commune_access_from_epci %>
+          <div class="mt-2 flex items-center text-sm text-indigo-600">
+            <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
+            </svg>
+            Accès depuis le dashboard EPCI
+            <button onclick="window.close()" class="ml-2 px-2 py-1 bg-indigo-100 text-indigo-700 rounded text-xs hover:bg-indigo-200">
+              Fermer cet onglet
+            </button>
+          </div>
+        <% end %>
+      </div>
       <span class="px-3 py-1 bg-indigo-100 text-indigo-800 rounded-full text-sm font-medium">
         Code INSEE: <%= @territory_code %>
       </span>

--- a/app/views/epci_dashboard/index.html.erb
+++ b/app/views/epci_dashboard/index.html.erb
@@ -8,6 +8,30 @@
       </span>
     </div>
 
+    <!-- Nouvelle section: Accès aux communes -->
+    <div class="bg-white shadow rounded-lg p-4 mb-6">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center space-x-4">
+          <h3 class="text-sm font-medium text-gray-700">Accéder au dashboard d'une commune :</h3>
+          <div class="relative">
+            <select id="commune-selector"
+                    class="block w-64 px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                    onchange="openCommuneDashboard(this.value)">
+              <option value="">Sélectionner une commune...</option>
+              <% if @epci_communes_data && @epci_communes_data["communes"] %>
+                <% @epci_communes_data["communes"].sort_by { |c| c["name"] }.each do |commune| %>
+                  <option value="<%= commune['code'] %>"><%= commune["name"] %> (<%= commune["code"] %>)</option>
+                <% end %>
+              <% end %>
+            </select>
+          </div>
+        </div>
+        <div class="text-sm text-gray-500">
+          <%= @epci_communes_data&.dig("communes")&.count || 0 %> communes dans cet EPCI
+        </div>
+      </div>
+    </div>
+
     <!-- Navigation par onglets -->
     <div class="border-b border-gray-200 mb-6">
       <nav class="-mb-px flex space-x-8 overflow-x-auto">
@@ -197,3 +221,18 @@
     </div>
   </div>
 </div>
+
+<script>
+function openCommuneDashboard(communeCode) {
+  if (communeCode) {
+    // Construire l'URL du dashboard de la commune
+    const url = `/dashboard?commune_code=${communeCode}`;
+
+    // Ouvrir dans un nouvel onglet
+    window.open(url, '_blank');
+
+    // Réinitialiser la sélection
+    document.getElementById('commune-selector').value = '';
+  }
+}
+</script>


### PR DESCRIPTION
Users with EPCI territory type can now access individual commune dashboards through a dropdown selector that opens commune data in a new tab.