### PR TITLE
feat: add commune_location question type for territorial surveys

### DIFF
--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -21,6 +21,10 @@ class Admin::QuestionsController < ApplicationController
       process_scale_options
     end
 
+    if @question.question_type == 'commune_location'
+      process_commune_location_options
+    end
+
     if @question.save
       if params[:commit] == "Créer et ajouter une autre"
         redirect_to new_admin_survey_survey_section_question_path(@survey, @section), notice: "Question créée. Vous pouvez en ajouter une autre."
@@ -39,6 +43,8 @@ class Admin::QuestionsController < ApplicationController
     # Traiter les options pour les questions à échelle
     if question_params[:question_type] == 'scale'
       process_scale_options
+    elsif question_params[:question_type] == 'commune_location'
+      process_commune_location_options
     end
 
     if @question.update(question_params)
@@ -103,6 +109,27 @@ class Admin::QuestionsController < ApplicationController
         position: position
       )
       position += 1
+    end
+  end
+
+  def process_commune_location_options
+    @question.options ||= {}
+
+    # Marquer que les communes doivent être chargées dynamiquement
+    @question.options['load_communes_dynamically'] = true
+
+    # Si l'enquête a déjà des destinataires, on peut stocker quelques infos de base
+    if @survey.user_surveys.any?
+      territory = @survey.user_surveys.first.user
+      @question.options['territory_type'] = territory.territory_type
+      @question.options['territory_code'] = territory.territory_code
+      @question.options['territory_name'] = territory.territory_name
+
+      # Note: On ne stocke PAS la liste des communes ici car :
+      # 1. Cela prendrait beaucoup de place dans le JSON
+      # 2. Les communes pourraient changer
+      # 3. Chaque utilisateur EPCI pourrait avoir des communes différentes
+      # Les communes seront chargées dynamiquement dans la vue
     end
   end
 end

--- a/app/javascript/controllers/commune_location_controller.js
+++ b/app/javascript/controllers/commune_location_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["yesRadio", "noRadio", "otherField", "communeSelect"]
+
+  connect() {
+    // Initialiser l'état au chargement
+    this.toggleOtherField()
+  }
+
+  toggleOtherField() {
+    if (!this.hasOtherFieldTarget) return
+
+    const otherInput = this.otherFieldTarget.querySelector('input')
+
+    // Pour commune : afficher si "Non" est sélectionné
+    if (this.hasNoRadioTarget && this.noRadioTarget.checked) {
+      this.showOtherField(otherInput)
+    }
+    // Pour EPCI : afficher si "Autre" est sélectionné
+    else if (this.hasCommuneSelectTarget && this.communeSelectTarget.value === 'other') {
+      this.showOtherField(otherInput)
+    } else {
+      this.hideOtherField(otherInput)
+    }
+  }
+
+  showOtherField(input) {
+    this.otherFieldTarget.classList.remove('hidden')
+    input.required = true
+  }
+
+  hideOtherField(input) {
+    this.otherFieldTarget.classList.add('hidden')
+    input.required = false
+    input.value = ''
+  }
+}

--- a/app/javascript/controllers/question_form_controller.js
+++ b/app/javascript/controllers/question_form_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["typeSelect", "optionsSection", "scaleSection", "preview", "optionsContainer", "title", "description", "required"]
+  static targets = ["typeSelect", "optionsSection", "scaleSection", "preview", "optionsContainer", "title", "description", "required", "communeLocationInfo"]
 
   connect() {
     this.optionCounter = this.optionsContainerTarget.querySelectorAll('.option-field').length
@@ -25,6 +25,11 @@ export default class extends Controller {
     this.optionsSectionTarget.classList.add('hidden')
     this.scaleSectionTarget.classList.add('hidden')
 
+    // Cacher la section commune_location si elle existe
+    if (this.hasCommuneLocationInfoTarget) {
+      this.communeLocationInfoTarget.classList.add('hidden')
+    }
+
     // Show appropriate sections
     switch(type) {
       case 'single_choice':
@@ -33,6 +38,11 @@ export default class extends Controller {
         break
       case 'scale':
         this.scaleSectionTarget.classList.remove('hidden')
+        break
+      case 'commune_location':
+        if (this.hasCommuneLocationInfoTarget) {
+          this.communeLocationInfoTarget.classList.remove('hidden')
+        }
         break
     }
   }
@@ -130,6 +140,8 @@ export default class extends Controller {
             </label>
           </div>
         `
+      case 'commune_location':
+        return this.generateCommuneLocationPreview()
       default:
         return ''
     }
@@ -193,5 +205,41 @@ export default class extends Controller {
     html += `</div>`
 
     return html
+  }
+
+  generateCommuneLocationPreview() {
+    return `
+      <div class="space-y-2">
+        <p class="text-sm text-gray-600 italic">
+          Cette question s'adaptera automatiquement selon le territoire du répondant.
+        </p>
+        <div class="border-l-4 border-blue-400 pl-4 space-y-4">
+          <div>
+            <p class="text-xs font-medium text-gray-700 mb-2">Exemple pour une commune :</p>
+            <div class="space-y-2">
+              <label class="flex items-center">
+                <input type="radio" name="preview_commune" disabled class="h-4 w-4 text-indigo-600">
+                <span class="ml-2 text-sm">Oui, j'habite à [Nom de la commune]</span>
+              </label>
+              <label class="flex items-center">
+                <input type="radio" name="preview_commune" disabled class="h-4 w-4 text-indigo-600">
+                <span class="ml-2 text-sm">Non, j'habite dans une autre commune</span>
+              </label>
+            </div>
+          </div>
+
+          <div>
+            <p class="text-xs font-medium text-gray-700 mb-2">Exemple pour un EPCI :</p>
+            <select disabled class="w-full rounded-md border-gray-300 shadow-sm text-sm">
+              <option>-- Sélectionnez votre commune --</option>
+              <option>Commune 1</option>
+              <option>Commune 2</option>
+              <option>...</option>
+              <option>Autre commune (hors EPCI)</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    `
   }
 }

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -19,6 +19,7 @@ class Question < ApplicationRecord
     phone
     date
     yes_no
+    commune_location
   ].freeze
 
   validates :question_type, inclusion: { in: QUESTION_TYPES }
@@ -26,8 +27,12 @@ class Question < ApplicationRecord
   before_validation :set_position, on: :create
   accepts_nested_attributes_for :question_options, allow_destroy: true
 
+  def commune_location_question?
+    question_type == 'commune_location'
+  end
+
   def requires_options?
-    %w[single_choice multiple_choice scale].include?(question_type)
+    %w[single_choice multiple_choice scale commune_location].include?(question_type)
   end
 
   def is_choice_question?
@@ -40,6 +45,14 @@ class Question < ApplicationRecord
 
   def is_text_question?
     %w[text long_text email phone].include?(question_type)
+  end
+
+  def multiple_choice?
+    question_type == 'multiple_choice'
+  end
+
+  def single_choice?
+    question_type == 'single_choice'
   end
 
   def validation_errors_for(answer)

--- a/app/models/question_response.rb
+++ b/app/models/question_response.rb
@@ -11,6 +11,9 @@ class QuestionResponse < ApplicationRecord
       answer_text
     when 'multiple_choice'
       answer_data.is_a?(Array) ? answer_data : []
+    when 'commune_location'
+      # Pour les questions commune_location, retourner l'answer_text
+      answer_text
     when 'scale', 'numeric'
       answer_text.to_i if answer_text.present?
     else
@@ -26,5 +29,80 @@ class QuestionResponse < ApplicationRecord
     else
       self.answer_text = value.to_s
     end
+  end
+
+  # Méthode pour formatter l'affichage de la réponse (utilisée dans l'export CSV)
+  def formatted_answer
+    case question.question_type
+    when 'single_choice', 'yes_no'
+      if question.question_type == 'yes_no'
+        answer_text == 'yes' ? 'Oui' : 'Non'
+      else
+        # Trouver l'option correspondante pour afficher le texte
+        option = question.question_options.find { |opt| opt.value == answer_text }
+        option&.text || answer_text
+      end
+    when 'multiple_choice'
+      if answer_data.is_a?(Array)
+        answer_data.map do |value|
+          option = question.question_options.find { |opt| opt.value == value }
+          option&.text || value
+        end.join(', ')
+      else
+        ''
+      end
+    when 'commune_location'
+      # Pour commune_location, afficher "Autre commune" pour les réponses "other"
+      if answer_data.present? && answer_data.is_a?(Hash)
+        if answer_data['type'] == 'other'
+          'Autre commune'  # Affichage uniforme pour toutes les autres communes
+        else
+          answer_data['commune_name'] || answer_text
+        end
+      else
+        # Fallback pour les anciennes données
+        if answer_text == 'other'
+          'Autre commune'
+        else
+          answer_text
+        end
+      end
+    when 'scale', 'numeric'
+      answer_text
+    else
+      answer_text
+    end
+  end
+
+  private
+
+  def process_commune_location_answer(value)
+    if value == 'other'
+      # La valeur "other" sera traitée dans le contrôleur
+      self.answer_data = {
+        'type' => 'other',
+        'commune_code' => value
+      }
+    else
+      # C'est un code INSEE de commune
+      commune_name = fetch_commune_name(value)
+      self.answer_data = {
+        'type' => 'commune',
+        'commune_code' => value,
+        'commune_name' => commune_name
+      }
+    end
+  end
+
+  def fetch_commune_name(code)
+    # Chercher d'abord dans les options de la question
+    if question.options && question.options['commune_list']
+      commune = question.options['commune_list'].find { |c| c['code'] == code }
+      return commune['name'] if commune
+    end
+
+    # Sinon, chercher dans la base de données
+    territory = Territory.find_by(codgeo: code)
+    territory&.libgeo || code
   end
 end

--- a/app/views/admin/questions/_commune_location_info.html.erb
+++ b/app/views/admin/questions/_commune_location_info.html.erb
@@ -1,0 +1,20 @@
+<div id="commune-location-info" class="mt-4 space-y-4 hidden" data-question-form-target="communeLocationInfo">
+  <div class="bg-blue-50 p-4 rounded-md">
+    <h4 class="text-sm font-medium text-blue-900 mb-2">
+      <svg class="inline w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+      </svg>
+      Information sur la question commune
+    </h4>
+    <p class="text-sm text-blue-700">
+      Cette question s'adaptera automatiquement selon le territoire du répondant :
+    </p>
+    <ul class="mt-2 text-sm text-blue-700 list-disc list-inside space-y-1">
+      <li><strong>Pour une commune :</strong> "Habitez-vous à [nom de la commune] ?" avec options Oui/Non</li>
+      <li><strong>Pour un EPCI :</strong> Liste déroulante des communes de l'EPCI + option "Autre"</li>
+    </ul>
+    <p class="mt-2 text-xs text-blue-600 italic">
+      Les communes seront automatiquement récupérées depuis la base de données.
+    </p>
+  </div>
+</div>

--- a/app/views/admin/questions/edit.html.erb
+++ b/app/views/admin/questions/edit.html.erb
@@ -69,7 +69,8 @@
                   ['Email', 'email'],
                   ['Téléphone', 'phone'],
                   ['Date', 'date'],
-                  ['Oui/Non', 'yes_no']
+                  ['Oui/Non', 'yes_no'],
+                  ['Commune d\'habitation', 'commune_location']  # AJOUTER CETTE LIGNE
                 ], @question.question_type),
                 { prompt: 'Sélectionnez un type' },
                 { class: "mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
@@ -79,6 +80,8 @@
                   }
                 } %>
               </div>
+
+              <%= render 'commune_location_info' %>
 
               <div>
                 <label class="flex items-center">

--- a/app/views/admin/questions/new.html.erb
+++ b/app/views/admin/questions/new.html.erb
@@ -69,8 +69,9 @@
                   ['Email', 'email'],
                   ['Téléphone', 'phone'],
                   ['Date', 'date'],
-                  ['Oui/Non', 'yes_no']
-                ]),
+                  ['Oui/Non', 'yes_no'],
+                  ['Commune d\'habitation', 'commune_location']  # AJOUTER CETTE LIGNE
+                ], @question.question_type),
                 { prompt: 'Sélectionnez un type' },
                 { class: "mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
                   data: {
@@ -79,6 +80,8 @@
                   }
                 } %>
               </div>
+
+              <%= render 'commune_location_info' %>
 
               <div>
                 <label class="flex items-center">

--- a/app/views/admin/surveys/_commune_location_results.html.erb
+++ b/app/views/admin/surveys/_commune_location_results.html.erb
@@ -1,0 +1,98 @@
+<!-- app/views/admin/surveys/_commune_location_results.html.erb -->
+<% if stats.present? && stats.any? %>
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+    <div>
+      <h4 class="text-lg font-semibold text-gray-900 mb-4">Répartition par commune</h4>
+
+      <% # Séparer les communes du territoire et les autres %>
+      <% territory_communes = {} %>
+      <% other_communes = {} %>
+      <% total_responses = stats.values.sum %>
+
+      <% stats.each do |commune_name, count| %>
+        <% if commune_name.to_s.start_with?('Autre:') %>
+          <% other_communes[commune_name] = count %>
+        <% else %>
+          <% territory_communes[commune_name] = count %>
+        <% end %>
+      <% end %>
+
+      <!-- Communes du territoire -->
+      <% if territory_communes.any? %>
+        <div class="space-y-3 mb-6">
+          <% territory_communes.sort_by { |_, count| -count }.each do |commune_name, count| %>
+            <% percentage = (count.to_f / total_responses * 100).round(1) %>
+            <div class="relative">
+              <div class="flex justify-between items-center mb-1">
+                <span class="text-sm font-medium text-gray-700"><%= commune_name %></span>
+                <span class="text-sm text-gray-600"><%= count %> (<%= percentage %>%)</span>
+              </div>
+              <div class="w-full bg-gray-200 rounded-full h-8 overflow-hidden">
+                <div class="h-full bg-gradient-to-r from-blue-500 to-indigo-600 rounded-full flex items-center justify-end pr-3 transition-all duration-500"
+                     style="width: <%= percentage %>%">
+                  <span class="text-white text-xs font-medium"><%= percentage %>%</span>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
+      <!-- Autres communes -->
+      <% if other_communes.any? %>
+        <div class="border-t border-gray-200 pt-4">
+          <h5 class="text-md font-semibold text-gray-700 mb-3">
+            Autres communes mentionnées (<%= other_communes.values.sum %> réponses)
+          </h5>
+          <div class="flex flex-wrap gap-2">
+            <% other_communes.each do |commune_name, count| %>
+              <% display_name = commune_name.to_s.gsub('Autre: ', '') %>
+              <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-orange-100 text-orange-800">
+                <%= display_name %> (<%= count %>)
+              </span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
+      <!-- Statistiques rapides -->
+      <div class="mt-6 bg-gray-50 rounded-lg p-4">
+        <h5 class="font-semibold text-gray-900 mb-2">Résumé</h5>
+        <div class="grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <span class="text-gray-600">Communes distinctes</span>
+            <div class="text-xl font-bold text-gray-900"><%= stats.keys.count %></div>
+          </div>
+          <% if other_communes.any? %>
+            <div>
+              <span class="text-gray-600">Hors territoire</span>
+              <div class="text-xl font-bold text-orange-600">
+                <%= (other_communes.values.sum.to_f / total_responses * 100).round(1) %>%
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <!-- Graphique -->
+    <div class="flex items-center justify-center">
+      <div class="w-full">
+        <canvas data-survey-results-target="chart"
+                data-chart-type="doughnut"
+                data-question-id="<%= question.id %>"
+                data-chart-data="<%= {
+                  labels: stats.map { |commune_name, _|
+                    commune_name.to_s.start_with?('Autre:') ?
+                      commune_name.to_s.gsub('Autre: ', '') :
+                      commune_name
+                  },
+                  values: stats.values
+                }.to_json %>"
+                class="max-h-64"></canvas>
+      </div>
+    </div>
+  </div>
+<% else %>
+  <p class="text-gray-500 italic">Aucune réponse de localisation</p>
+<% end %>

--- a/app/views/public_surveys/_commune_location_question.html.erb
+++ b/app/views/public_surveys/_commune_location_question.html.erb
@@ -1,0 +1,81 @@
+<div class="space-y-3" data-controller="commune-location">
+  <%
+    user_territory = @user_survey&.user
+    question_options = question.options || {}
+  %>
+
+  <% if user_territory&.territory_type == 'commune' %>
+    <!-- Pour une commune : question Oui/Non avec champ texte conditionnel -->
+    <div class="space-y-2">
+      <label class="flex items-center p-2 hover:bg-gray-100 rounded cursor-pointer">
+        <%= radio_button_tag "responses[#{question.id}]",
+            user_territory.territory_code,
+            false,
+            class: "h-4 w-4 text-indigo-600 border-gray-300",
+            data: {
+              commune_location_target: "yesRadio",
+              action: "change->commune-location#toggleOtherField"
+            },
+            required: question.required? %>
+        <span class="ml-2">Oui, j'habite à <%= user_territory.territory_name %></span>
+      </label>
+
+      <label class="flex items-center p-2 hover:bg-gray-100 rounded cursor-pointer">
+        <%= radio_button_tag "responses[#{question.id}]",
+            "other",
+            false,
+            class: "h-4 w-4 text-indigo-600 border-gray-300",
+            data: {
+              commune_location_target: "noRadio",
+              action: "change->commune-location#toggleOtherField"
+            },
+            required: question.required? %>
+        <span class="ml-2">Non, j'habite dans une autre commune</span>
+      </label>
+
+      <div class="ml-6 hidden" data-commune-location-target="otherField">
+        <%= text_field_tag "responses[#{question.id}_other]",
+            nil,
+            placeholder: "Précisez votre commune",
+            class: "mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" %>
+      </div>
+    </div>
+
+  <% elsif user_territory&.territory_type == 'epci' %>
+    <!-- Pour un EPCI : liste déroulante des communes -->
+    <div class="space-y-2">
+      <%
+        # Charger les communes de l'EPCI depuis la base de données
+        communes = Territory.where(epci: user_territory.territory_code)
+                           .order(:libgeo)
+                           .select(:codgeo, :libgeo)
+      %>
+      <%= select_tag "responses[#{question.id}]",
+          options_for_select(
+            [['-- Sélectionnez votre commune --', '']] +
+            communes.map { |c| [c.libgeo, c.codgeo] } +
+            [['Autre commune (hors EPCI)', 'other']]
+          ),
+          class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
+          data: {
+            commune_location_target: "communeSelect",
+            action: "change->commune-location#toggleOtherField"
+          },
+          required: question.required? %>
+
+      <div class="hidden" data-commune-location-target="otherField">
+        <%= text_field_tag "responses[#{question.id}_other]",
+            nil,
+            placeholder: "Précisez votre commune",
+            class: "mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" %>
+      </div>
+    </div>
+  <% else %>
+    <!-- Cas par défaut si pas de territoire défini -->
+    <div class="p-4 bg-yellow-50 border border-yellow-200 rounded-md">
+      <p class="text-sm text-yellow-800">
+        Cette question nécessite un territoire défini. Veuillez contacter l'administrateur.
+      </p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/public_surveys/show.html.erb
+++ b/app/views/public_surveys/show.html.erb
@@ -152,6 +152,9 @@
                       placeholder: "0",
                       required: question.required? %>
 
+                <% when 'commune_location' %>
+                  <%= render 'commune_location_question', question: question %>
+
                 <% when 'yes_no' %>
                   <div class="flex space-x-4">
                     <label class="flex items-center">

--- a/app/views/user_surveys/_commune_location_results.html.erb
+++ b/app/views/user_surveys/_commune_location_results.html.erb
@@ -1,0 +1,123 @@
+<!-- app/views/user_surveys/_commune_location_results.html.erb -->
+<% if stats.present? && stats.any? %>
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+    <div>
+      <h4 class="text-lg font-semibold text-gray-900 mb-4">Répartition par commune</h4>
+
+      <% # Séparer les communes du territoire et les autres %>
+      <% territory_communes = {} %>
+      <% autres_communes_count = 0 %>
+      <% autres_communes_detail = {} %>
+
+      <% # Calculer le total en excluant les métadonnées %>
+      <% total_responses = stats.reject { |k, v| k.to_s.start_with?('_') }.values.sum %>
+
+      <% stats.each do |commune_name, count| %>
+        <% case commune_name.to_s %>
+        <% when 'Autres communes' %>
+          <% autres_communes_count = count %>
+        <% when '_autres_detail' %>
+          <% autres_communes_detail = count %>
+        <% else %>
+          <% territory_communes[commune_name] = count %>
+        <% end %>
+      <% end %>
+
+      <!-- Communes du territoire -->
+      <% if territory_communes.any? %>
+        <div class="space-y-3 mb-6">
+          <% territory_communes.sort_by { |_, count| -count }.each do |commune_name, count| %>
+            <% percentage = (count.to_f / total_responses * 100).round(1) %>
+            <div class="relative">
+              <div class="flex justify-between items-center mb-1">
+                <span class="text-sm font-medium text-gray-700"><%= commune_name %></span>
+                <span class="text-sm text-gray-600"><%= count %> (<%= percentage %>%)</span>
+              </div>
+              <div class="w-full bg-gray-200 rounded-full h-8 overflow-hidden">
+                <div class="h-full bg-gradient-to-r from-blue-500 to-indigo-600 rounded-full flex items-center justify-end pr-3 transition-all duration-500"
+                     style="width: <%= percentage %>%">
+                  <span class="text-white text-xs font-medium"><%= percentage %>%</span>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
+      <!-- Autres communes avec une section dédiée -->
+      <% if autres_communes_count > 0 %>
+        <!-- D'abord, ajouter "Autres communes" comme une entrée consolidée -->
+        <% percentage_autres = (autres_communes_count.to_f / total_responses * 100).round(1) %>
+
+        <div class="relative border-t border-gray-200 pt-4">
+          <div class="flex justify-between items-center mb-1">
+            <span class="text-sm font-medium text-gray-700">Autres communes</span>
+            <span class="text-sm text-gray-600"><%= autres_communes_count %> (<%= percentage_autres %>%)</span>
+          </div>
+          <div class="w-full bg-gray-200 rounded-full h-8 overflow-hidden">
+            <div class="h-full bg-gradient-to-r from-orange-500 to-red-600 rounded-full flex items-center justify-end pr-3 transition-all duration-500"
+                 style="width: <%= percentage_autres %>%">
+              <span class="text-white text-xs font-medium"><%= percentage_autres %>%</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Puis, détailler les communes mentionnées -->
+        <% if autres_communes_detail.any? %>
+          <div class="mt-4 bg-orange-50 rounded-lg p-4">
+            <h5 class="text-sm font-semibold text-gray-700 mb-3">
+              <svg class="w-4 h-4 inline-block mr-1" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
+              </svg>
+              Détail des autres communes mentionnées :
+            </h5>
+            <div class="flex flex-wrap gap-2">
+              <% autres_communes_detail.sort_by { |_, count| -count }.each do |commune_name, count| %>
+                <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-white border border-orange-200 text-orange-800">
+                  <%= commune_name %> (<%= count %>)
+                </span>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+
+      <!-- Statistiques rapides -->
+      <div class="mt-6 bg-gray-50 rounded-lg p-4">
+        <h5 class="font-semibold text-gray-900 mb-2">Résumé</h5>
+        <div class="grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <span class="text-gray-600">Communes distinctes</span>
+            <div class="text-xl font-bold text-gray-900">
+              <%= territory_communes.keys.count + (autres_communes_count > 0 ? 1 : 0) %>
+            </div>
+          </div>
+          <% if autres_communes_count > 0 %>
+            <div>
+              <span class="text-gray-600">Hors territoire</span>
+              <div class="text-xl font-bold text-orange-600">
+                <%= (autres_communes_count.to_f / total_responses * 100).round(1) %>%
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <!-- Graphique -->
+    <div class="flex items-center justify-center">
+      <div class="w-full">
+        <canvas data-survey-results-target="chart"
+                data-chart-type="doughnut"
+                data-question-id="<%= question.id %>"
+                data-chart-data="<%= {
+                  labels: territory_communes.keys + (autres_communes_count > 0 ? ['Autres communes'] : []),
+                  values: territory_communes.values + (autres_communes_count > 0 ? [autres_communes_count] : [])
+                }.to_json %>"
+                class="max-h-64"></canvas>
+      </div>
+    </div>
+  </div>
+<% else %>
+  <p class="text-gray-500 italic">Aucune réponse de localisation</p>
+<% end %>

--- a/app/views/user_surveys/results.html.erb
+++ b/app/views/user_surveys/results.html.erb
@@ -329,6 +329,9 @@
                       <p class="text-gray-500 italic">Aucune réponse</p>
                     <% end %>
 
+                  <% when 'commune_location' %>
+                    <%= render 'commune_location_results', question: question, stats: stats %>
+
                   <% else %>
                     <!-- Questions texte, email, phone, date -->
                     <% if stats[:total_responses] > 0 %>


### PR DESCRIPTION
Implement a new question type specifically designed for collecting respondent location data in territorial surveys, with adaptive UI based on user territory type.

Features:
- Adaptive question display: Yes/No for communes, dropdown for EPCI
- Smart data storage with commune codes and names in answer_data
- Proper handling of other responses with text input
- Grouped statistics calculation for accurate percentages
- Enhanced CSV export with separate columns for location details
- Support for multiple responses per session (field surveys)

Technical changes:
- Add 'commune_location' to Question.QUESTION_TYPES
- Implement commune_location_question? method
- Create specialized partial for location questions
- Update statistics calculation to group other responses
- Modify CSV export to include detailed location columns
- Add formatted_answer method for proper display
- Enable multiple survey responses for field work scenarios

This enables accurate territorial analysis while maintaining data quality and user experience across different user types.