### PR TITLE
feat: Add ranking question type with drag-and-drop interface

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -48,3 +48,56 @@
   width: 100% !important;
   height: 500px !important;
 }
+
+/* Styles améliorés pour les questions de classement */
+.ranking-item {
+  transition: all 0.2s ease;
+  cursor: grab;
+}
+
+.ranking-item:active {
+  cursor: grabbing;
+}
+
+.ranking-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+  border-color: #3b82f6;
+}
+
+/* États de drag & drop plus visibles */
+.sortable-ghost {
+  opacity: 0.3;
+  background: linear-gradient(45deg, #f3f4f6, #e5e7eb);
+  border: 2px dashed #9ca3af;
+  transform: rotate(2deg);
+}
+
+.sortable-chosen {
+  background: #dbeafe;
+  border-color: #3b82f6;
+  box-shadow: 0 10px 30px rgba(59, 130, 246, 0.3);
+  transform: scale(1.02);
+}
+
+.sortable-drag {
+  opacity: 0.8;
+  transform: rotate(-2deg) scale(1.05);
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.25);
+  z-index: 1000;
+}
+
+/* Animation de drop */
+.ranking-item.sortable-fallback {
+  opacity: 0;
+}
+
+/* Indicateur visuel pour le grip */
+.ranking-grip {
+  opacity: 0.4;
+  transition: opacity 0.2s ease;
+}
+
+.ranking-item:hover .ranking-grip {
+  opacity: 1;
+}

--- a/app/javascript/controllers/question_form_controller.js
+++ b/app/javascript/controllers/question_form_controller.js
@@ -11,7 +11,7 @@ export default class extends Controller {
     "description",
     "required",
     "communeLocationInfo",
-    "weeklyScheduleConfig"  // Nouvelle target pour weekly_schedule
+    "weeklyScheduleConfig"
   ]
 
   connect() {
@@ -39,6 +39,7 @@ export default class extends Controller {
     switch(type) {
       case 'single_choice':
       case 'multiple_choice':
+      case 'ranking':  // ← Nouveau cas ajouté
         this.showOptionsConfig()
         break
       case 'scale':
@@ -195,6 +196,8 @@ export default class extends Controller {
         return this.generateRadioOptions()
       case 'multiple_choice':
         return this.generateCheckboxOptions()
+      case 'ranking':  // ← Nouveau cas ajouté
+        return this.generateRankingPreview()
       case 'scale':
         return this.generateScalePreview()
       case 'text':
@@ -266,6 +269,46 @@ export default class extends Controller {
       `
     })
     html += '</div>'
+    return html
+  }
+
+  // ← Nouvelle méthode pour la prévisualisation du ranking
+  generateRankingPreview() {
+    const options = this.getOptionsFromForm()
+    if (options.length === 0) {
+      return '<p class="text-sm text-gray-500 italic">Ajoutez des options pour voir l\'aperçu du classement</p>'
+    }
+
+    let html = `
+      <div class="space-y-3">
+        <div class="bg-blue-50 p-3 rounded-md">
+          <p class="text-sm text-blue-700">
+            <i class="fas fa-info-circle"></i>
+            Glissez-déposez les éléments pour les classer par ordre de priorité
+          </p>
+        </div>
+
+        <div class="space-y-2 border border-gray-200 rounded-lg p-3">
+    `
+
+    options.forEach((option, index) => {
+      html += `
+        <div class="bg-white border border-gray-300 rounded-lg p-3 cursor-move hover:bg-gray-50 transition-colors">
+          <div class="flex items-center justify-between">
+            <span class="font-medium">${option}</span>
+            <div class="flex items-center space-x-2">
+              <span class="bg-blue-100 text-blue-800 px-2 py-1 rounded-full text-sm font-bold">${index + 1}</span>
+              <i class="fas fa-grip-vertical text-gray-400"></i>
+            </div>
+          </div>
+        </div>
+      `
+    })
+
+    html += `
+        </div>
+      </div>
+    `
     return html
   }
 

--- a/app/javascript/controllers/ranking_question_controller.js
+++ b/app/javascript/controllers/ranking_question_controller.js
@@ -1,0 +1,62 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["sortableList", "item", "rankNumber", "hiddenInput"]
+
+  connect() {
+    this.sortable = window.Sortable.create(this.sortableListTarget, {
+      animation: 300,
+      ghostClass: "sortable-ghost",
+      chosenClass: "sortable-chosen",
+      dragClass: "sortable-drag",
+      forceFallback: false,
+      fallbackClass: "sortable-fallback",
+      scroll: true,
+      scrollSensitivity: 100,
+      scrollSpeed: 20,
+      onStart: this.onDragStart.bind(this),
+      onEnd: this.onDragEnd.bind(this)
+    })
+
+    // Initialiser l'ordre par défaut
+    this.updateRanking()
+  }
+
+  disconnect() {
+    if (this.sortable) {
+      this.sortable.destroy()
+    }
+  }
+
+  onDragStart(evt) {
+    // Ajouter un feedback visuel quand le drag commence
+    this.sortableListTarget.classList.add('border-blue-400', 'bg-blue-50')
+  }
+
+  onDragEnd(evt) {
+    // Retirer le feedback visuel et mettre à jour
+    this.sortableListTarget.classList.remove('border-blue-400', 'bg-blue-50')
+    this.updateRanking()
+  }
+
+  updateRanking() {
+    const orderedValues = []
+
+    this.itemTargets.forEach((item, index) => {
+      const rankNumber = item.querySelector('[data-ranking-question-target="rankNumber"]')
+      rankNumber.textContent = index + 1
+
+      // Animation du changement de numéro
+      rankNumber.classList.add('animate-pulse')
+      setTimeout(() => {
+        rankNumber.classList.remove('animate-pulse')
+      }, 600)
+
+      const optionValue = item.dataset.optionValue
+      orderedValues.push(optionValue)
+    })
+
+    // Mettre à jour le champ caché avec l'ordre
+    this.hiddenInputTarget.value = JSON.stringify(orderedValues)
+  }
+}

--- a/app/javascript/controllers/survey_results_controller.js
+++ b/app/javascript/controllers/survey_results_controller.js
@@ -1,4 +1,3 @@
-// app/javascript/controllers/survey_results_controller.js
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
@@ -112,6 +111,9 @@ export default class extends Controller {
         case 'bar':
           chart = this.createBarChart(canvas, chartData)
           break
+        case 'horizontalBar':
+          chart = this.createRankingChart(canvas, chartData)
+          break
         case 'line':
           chart = this.createLineChart(canvas, chartData)
           break
@@ -169,6 +171,105 @@ export default class extends Controller {
               padding: 15,
               boxWidth: 15
             }
+          }
+        }
+      }
+    })
+  }
+
+  createRankingChart(canvas, data) {
+    const ctx = canvas.getContext('2d')
+
+    // Inverser l'ordre pour que le meilleur apparaisse en haut
+    const reversedLabels = [...data.labels].reverse()
+    const reversedValues = [...data.values].reverse()
+
+    // Créer un gradient de couleur du vert au rouge
+    const backgroundColors = reversedValues.map((value, index) => {
+      const position = index / (reversedValues.length - 1)
+      if (position <= 0.33) {
+        return `rgba(34, 197, 94, 0.8)` // Vert pour les meilleurs
+      } else if (position <= 0.66) {
+        return `rgba(234, 179, 8, 0.8)` // Jaune pour les moyens
+      } else {
+        return `rgba(239, 68, 68, 0.8)` // Rouge pour les moins bons
+      }
+    })
+
+    const borderColors = backgroundColors.map(color => color.replace('0.8', '1'))
+
+    return new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: reversedLabels,
+        datasets: [{
+          label: 'Rang moyen',
+          data: reversedValues,
+          backgroundColor: backgroundColors,
+          borderColor: borderColors,
+          borderWidth: 2,
+          borderRadius: 6,
+          borderSkipped: false,
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        indexAxis: 'y', // Barres horizontales
+        scales: {
+          x: {
+            title: {
+              display: true,
+              text: 'Rang moyen (1 = meilleur)',
+              font: {
+                weight: 'bold'
+              }
+            },
+            min: 1,
+            max: data.total_options,
+            reverse: true, // 1 à gauche, max à droite
+            grid: {
+              color: 'rgba(0, 0, 0, 0.1)'
+            }
+          },
+          y: {
+            title: {
+              display: true,
+              text: 'Options',
+              font: {
+                weight: 'bold'
+              }
+            },
+            grid: {
+              display: false
+            }
+          }
+        },
+        plugins: {
+          legend: {
+            display: false
+          },
+          tooltip: {
+            callbacks: {
+              label: function(context) {
+                const rank = context.parsed.x
+                const position = reversedLabels.length - context.dataIndex
+                let medal = ''
+                if (position === 1) medal = '🥇 '
+                else if (position === 2) medal = '🥈 '
+                else if (position === 3) medal = '🥉 '
+
+                return `${medal}Rang moyen: ${rank.toFixed(1)}`
+              }
+            }
+          }
+        },
+        layout: {
+          padding: {
+            left: 10,
+            right: 10,
+            top: 10,
+            bottom: 10
           }
         }
       }

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -21,6 +21,7 @@ class Question < ApplicationRecord
     yes_no
     commune_location
     weekly_schedule
+    ranking
   ].freeze
 
   validates :question_type, inclusion: { in: QUESTION_TYPES }
@@ -54,6 +55,14 @@ class Question < ApplicationRecord
 
   def single_choice?
     question_type == 'single_choice'
+  end
+
+  def ranking_question?
+    question_type == 'ranking'
+  end
+
+  def requires_options?
+    %w[single_choice multiple_choice scale commune_location weekly_schedule ranking].include?(question_type)
   end
 
   def validation_errors_for(answer)

--- a/app/models/question_response.rb
+++ b/app/models/question_response.rb
@@ -11,6 +11,8 @@ class QuestionResponse < ApplicationRecord
       answer_text
     when 'multiple_choice', 'weekly_schedule'
       answer_data.is_a?(Array) ? answer_data : []
+    when 'ranking'
+      answer_data.is_a?(Array) ? answer_data : []
     when 'commune_location'
       # Pour les questions commune_location, retourner l'answer_text
       answer_text
@@ -23,7 +25,7 @@ class QuestionResponse < ApplicationRecord
 
   def answer=(value)
     case question.question_type
-    when 'multiple_choice'
+    when 'multiple_choice', 'ranking'
       self.answer_data = value.is_a?(Array) ? value : [value].compact
       self.answer_text = answer_data.join(', ')
     else
@@ -52,6 +54,16 @@ class QuestionResponse < ApplicationRecord
         # Trouver l'option correspondante pour afficher le texte
         option = question.question_options.find { |opt| opt.value == answer_text }
         option&.text || answer_text
+      end
+    when 'ranking'
+      if answer_data.is_a?(Array) && answer_data.any?
+        answer_data.map.with_index(1) do |option_value, rank|
+          option = question.question_options.find { |opt| opt.value == option_value }
+          option_text = option&.text || option_value
+          "#{rank}. #{option_text}"
+        end.join(', ')
+      else
+        'Aucun classement'
       end
     when 'multiple_choice'
       if answer_data.is_a?(Array)

--- a/app/views/admin/questions/edit.html.erb
+++ b/app/views/admin/questions/edit.html.erb
@@ -71,7 +71,8 @@
                   ['Date', 'date'],
                   ['Oui/Non', 'yes_no'],
                   ['Commune d\'habitation', 'commune_location'],
-                  ['Planning horaire hebdomadaire', 'weekly_schedule']
+                  ['Planning horaire hebdomadaire', 'weekly_schedule'],
+                  ['Classement/Ordre de priorité', 'ranking']
                 ], @question.question_type),
                 { prompt: 'Sélectionnez un type' },
                 { class: "mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",

--- a/app/views/admin/questions/new.html.erb
+++ b/app/views/admin/questions/new.html.erb
@@ -71,7 +71,8 @@
                   ['Date', 'date'],
                   ['Oui/Non', 'yes_no'],
                   ['Commune d\'habitation', 'commune_location'],
-                  ['Planning horaire hebdomadaire', 'weekly_schedule']
+                  ['Planning horaire hebdomadaire', 'weekly_schedule'],
+                  ['Classement/Ordre de priorité', 'ranking']
                 ], @question.question_type),
                 { prompt: 'Sélectionnez un type' },
                 { class: "mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",

--- a/app/views/admin/surveys/preview.html.erb
+++ b/app/views/admin/surveys/preview.html.erb
@@ -108,6 +108,31 @@
                     <% end %>
                   </div>
 
+                <% when 'ranking' %>
+                  <div class="space-y-3">
+                    <div class="bg-blue-50 p-3 rounded-md">
+                      <p class="text-sm text-blue-700">
+                        <i class="fas fa-info-circle"></i>
+                        Glissez-déposez les éléments pour les classer par ordre de priorité (prévisualisation)
+                      </p>
+                    </div>
+
+                    <div class="space-y-2 border border-gray-200 rounded-lg p-3">
+                      <% question.question_options.each_with_index do |option, index| %>
+                        <div class="bg-white border border-gray-300 rounded-lg p-3">
+                          <div class="flex items-center justify-between">
+                            <span class="font-medium"><%= option.text %></span>
+                            <div class="flex items-center space-x-2">
+                              <span class="bg-blue-100 text-blue-800 px-2 py-1 rounded-full text-sm font-bold"><%= index + 1 %></span>
+                              <i class="fas fa-grip-vertical text-gray-400"></i>
+                            </div>
+                          </div>
+                        </div>
+                      <% end %>
+                    </div>
+                  </div>
+
+
                 <% when 'weekly_schedule' %>
                   <%= render 'weekly_schedule_preview', question: question %>
 

--- a/app/views/layouts/public_survey.html.erb
+++ b/app/views/layouts/public_survey.html.erb
@@ -11,6 +11,7 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
 
     <!-- JavaScript -->
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>  <!-- ← AJOUTEZ CETTE LIGNE -->
     <%= javascript_importmap_tags %>
   </head>
 

--- a/app/views/public_surveys/show.html.erb
+++ b/app/views/public_surveys/show.html.erb
@@ -96,6 +96,51 @@
                     <% end %>
                   </div>
 
+                <% when 'ranking' %>
+                  <div data-controller="ranking-question" data-ranking-question-name="responses[<%= question.id %>]">
+                    <div class="bg-blue-50 border border-blue-200 p-4 rounded-lg mb-4">
+                      <div class="flex items-center">
+                        <svg class="h-5 w-5 text-blue-500 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
+                        </svg>
+                        <p class="text-sm text-blue-700 font-medium">
+                          Glissez-déposez les éléments pour les classer par ordre de priorité
+                        </p>
+                      </div>
+                      <p class="text-xs text-blue-600 mt-1 ml-7">1er = plus important • Dernière position = moins important</p>
+                    </div>
+
+                    <div data-ranking-question-target="sortableList" class="space-y-3 bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg p-4">
+                      <% question.question_options.each_with_index do |option, index| %>
+                        <div class="ranking-item bg-white border-2 border-gray-200 rounded-lg p-4 shadow-sm"
+                             data-option-value="<%= option.value %>"
+                             data-ranking-question-target="item">
+                          <div class="flex items-center justify-between">
+                            <div class="flex items-center flex-1">
+                              <div class="ranking-grip mr-3 text-gray-400">
+                                <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l4-4 4 4m0 6l-4 4-4-4" />
+                                </svg>
+                              </div>
+                              <span class="font-medium text-gray-800 flex-1"><%= option.text %></span>
+                            </div>
+                            <div class="flex items-center space-x-2">
+                              <span class="text-xs text-gray-500 font-medium">Position</span>
+                              <span class="ranking-number bg-indigo-500 text-white px-3 py-1 rounded-full text-sm font-bold min-w-[2rem] text-center"
+                                    data-ranking-question-target="rankNumber"><%= index + 1 %></span>
+                            </div>
+                          </div>
+                        </div>
+                      <% end %>
+                    </div>
+
+                    <!-- Champ caché pour stocker l'ordre -->
+                    <input type="hidden"
+                           name="responses[<%= question.id %>]"
+                           data-ranking-question-target="hiddenInput"
+                           <% if question.required? %>required<% end %>>
+                  </div>
+
                 <% when 'scale' %>
                   <div class="flex items-center justify-between mt-4">
                     <% if question.options && question.options['scale_min_label'] %>

--- a/app/views/user_surveys/results.html.erb
+++ b/app/views/user_surveys/results.html.erb
@@ -239,6 +239,101 @@
                       </div>
                     </div>
 
+                  <% when 'ranking' %>
+                    <% if stats && stats[:total_responses] > 0 %>
+                      <div>
+                        <h4 class="text-lg font-semibold text-gray-800 mb-4">Classement moyen</h4>
+
+                        <div class="space-y-3">
+                          <%
+                            # Calculer les positions avec gestion des ex-aequo
+                            previous_rank = nil
+                            visual_position = 0
+                            display_position = 0
+                          %>
+
+                          <% stats[:sorted_options].each_with_index do |(option_value, avg_rank), index| %>
+                            <% option = question.question_options.find { |o| o.value == option_value } %>
+                            <% option_text = option&.text || option_value %>
+                            <% rank_percentage = ((question.question_options.count - avg_rank + 1) / question.question_options.count.to_f * 100).round(1) %>
+
+                            <%
+                              # Gestion des positions avec ex-aequo
+                              if previous_rank != avg_rank
+                                visual_position = index
+                                display_position = index + 1
+                              end
+                              # Sinon on garde la même visual_position et display_position
+
+                              previous_rank = avg_rank
+                            %>
+
+                            <div class="flex items-center space-x-4 py-2">
+                              <!-- Médaille/Position -->
+                              <div class="flex-shrink-0 w-8">
+                                <% if visual_position == 0 %>
+                                  <span class="text-xl">🥇</span>
+                                <% elsif visual_position == 1 %>
+                                  <span class="text-xl">🥈</span>
+                                <% elsif visual_position == 2 %>
+                                  <span class="text-xl">🥉</span>
+                                <% else %>
+                                  <span class="bg-gray-100 text-gray-600 px-2 py-1 rounded-full text-sm font-bold w-6 h-6 flex items-center justify-center">
+                                    <%= display_position %>
+                                  </span>
+                                <% end %>
+                              </div>
+
+                              <!-- Intitulé de l'option -->
+                              <div class="w-64 flex-shrink-0">
+                                <span class="font-medium text-gray-800 text-sm"><%= option_text %></span>
+                              </div>
+
+                              <!-- Barre de progression -->
+                              <div class="flex-1 min-w-0">
+                                <div class="w-full bg-gray-200 rounded-full h-4">
+                                  <%
+                                    # Couleurs selon la position visuelle (pas l'index)
+                                    if visual_position == 0
+                                      color_class = "bg-gradient-to-r from-green-400 to-green-600"
+                                    elsif visual_position == 1
+                                      color_class = "bg-gradient-to-r from-emerald-400 to-emerald-600"
+                                    elsif visual_position == 2
+                                      color_class = "bg-gradient-to-r from-yellow-400 to-yellow-600"
+                                    else
+                                      color_class = "bg-gradient-to-r from-red-400 to-red-600"
+                                    end
+                                  %>
+                                  <div class="h-full <%= color_class %> rounded-full transition-all duration-500"
+                                       style="width: <%= rank_percentage %>%">
+                                  </div>
+                                </div>
+                              </div>
+
+                              <!-- Rang moyen -->
+                              <div class="flex-shrink-0 w-20 text-right">
+                                <div class="text-sm font-bold text-gray-900">
+                                  <%= avg_rank.round(1) %>
+                                </div>
+                                <div class="text-xs text-gray-500">
+                                  <%= stats[:option_counts][option_value] %> vote<%= stats[:option_counts][option_value] > 1 ? 's' : '' %>
+                                </div>
+                              </div>
+                            </div>
+                          <% end %>
+                        </div>
+
+                        <div class="mt-4 p-3 bg-blue-50 rounded-lg">
+                          <p class="text-sm text-blue-700">
+                            <strong>Lecture :</strong> Rang moyen calculé sur <%= stats[:total_responses] %> réponse<%= stats[:total_responses] > 1 ? 's' : '' %>.
+                            Plus le rang est proche de 1, plus l'option est considérée comme prioritaire.
+                          </p>
+                        </div>
+                      </div>
+                    <% else %>
+                      <p class="text-gray-500 italic">Aucune réponse de classement</p>
+                    <% end %>
+
                   <% when 'multiple_choice' %>
                     <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
                       <div>


### PR DESCRIPTION
- Add 'ranking' to Question model QUESTION_TYPES
- Implement drag-and-drop sortable interface using SortableJS
- Create Stimulus controller for ranking functionality
- Add ranking support to admin forms and preview
- Calculate average rankings with ex-aequo handling
- Display results with medals and color-coded horizontal bars
- Enhance CSV export with separate columns per ranking position
- Add French ordinal numbers (1er, 2e, 3e) and UTF-8 encoding
- Handle double-encoded JSON data parsing

Complete ranking question implementation with intuitive UX, statistical analysis, and proper data export.