### PR TITLE
feat: Add Other option support for single/multiple choice questions

### DIFF
--- a/app/javascript/controllers/other_option_controller.js
+++ b/app/javascript/controllers/other_option_controller.js
@@ -1,0 +1,43 @@
+// app/javascript/controllers/other_option_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["trigger", "input"]
+
+  connect() {
+    // Initialiser l'état des champs au chargement de la page
+    this.triggerTargets.forEach(trigger => {
+      this.updateOtherInput(trigger)
+    })
+  }
+
+  toggleOtherInput(event) {
+    this.updateOtherInput(event.target)
+  }
+
+  updateOtherInput(trigger) {
+    const questionId = trigger.dataset.questionId
+    const otherInput = this.inputTargets.find(input =>
+      input.dataset.questionId === questionId
+    )
+
+    if (!otherInput) return
+
+    const isChecked = trigger.checked
+    const inputField = otherInput.querySelector('input[type="text"]')
+
+    if (isChecked) {
+      // Afficher le champ de saisie et lui donner le focus
+      otherInput.style.display = 'block'
+      if (inputField) {
+        inputField.focus()
+      }
+    } else {
+      // Masquer le champ et vider sa valeur
+      otherInput.style.display = 'none'
+      if (inputField) {
+        inputField.value = ''
+      }
+    }
+  }
+}

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -33,10 +33,6 @@ class Question < ApplicationRecord
     question_type == 'commune_location'
   end
 
-  def requires_options?
-    %w[single_choice multiple_choice scale commune_location].include?(question_type)
-  end
-
   def is_choice_question?
     %w[single_choice multiple_choice].include?(question_type)
   end
@@ -59,6 +55,15 @@ class Question < ApplicationRecord
 
   def ranking_question?
     question_type == 'ranking'
+  end
+
+  def has_other_option?
+    return false unless is_choice_question?
+    options&.dig('has_other_option') == true
+  end
+
+  def supports_other_option?
+    %w[single_choice multiple_choice].include?(question_type)
   end
 
   def requires_options?

--- a/app/views/admin/questions/edit.html.erb
+++ b/app/views/admin/questions/edit.html.erb
@@ -1,4 +1,3 @@
-<!-- app/views/admin/questions/edit.html.erb -->
 <div class="py-6">
   <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex justify-between items-center mb-6">
@@ -83,7 +82,7 @@
                 } %>
               </div>
 
-              <%= render 'commune_location_info' if defined?(render) %>
+              <%= render 'commune_location_info' if defined?(@question) %>
 
               <%= render 'weekly_schedule_config' %>
 
@@ -142,6 +141,34 @@
               </svg>
               Ajouter une option
             </button>
+
+            <!-- Option "Autre" pour les questions de choix -->
+            <div data-question-form-target="otherOptionContainer" class="border border-gray-200 rounded-lg p-4 bg-gray-50">
+              <h4 class="font-medium text-gray-900 mb-3">Option "Autre"</h4>
+
+              <div class="flex items-center mb-3">
+                <%= check_box_tag :has_other_option, '1',
+                    @question.has_other_option?,
+                    class: "h-4 w-4 text-indigo-600 border-gray-300 rounded",
+                    data: {
+                      question_form_target: "otherOptionToggle",
+                      action: "change->question-form#toggleOtherOption"
+                    } %>
+                <%= label_tag :has_other_option, "Ajouter une option 'Autre' avec champ texte",
+                    class: "ml-2 text-sm text-gray-700" %>
+              </div>
+
+              <div data-question-form-target="otherTextLabelContainer"
+                   style="<%= @question.has_other_option? ? 'display: block;' : 'display: none;' %>">
+                <%= label_tag :other_text_label, "Libellé de l'option autre",
+                    class: "block text-sm font-medium text-gray-700 mb-1" %>
+                <%= text_field_tag :other_text_label,
+                    @question.options&.dig('other_text_label') || 'Autre (précisez)',
+                    class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
+                    data: { action: "input->question-form#updatePreview" } %>
+                <p class="mt-1 text-xs text-gray-500">Ce texte apparaîtra comme option dans le questionnaire</p>
+              </div>
+            </div>
           </div>
 
           <!-- Configuration pour les échelles -->
@@ -152,25 +179,27 @@
               <div>
                 <label class="block text-sm font-medium text-gray-700">Valeur minimum</label>
                 <input type="number"
-                       id="scale_min"
                        name="scale_min"
                        value="<%= @question.options&.dig('scale_min') || 1 %>"
+                       min="0"
                        class="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
                        data-action="input->question-form#updatePreview">
               </div>
+
               <div>
                 <label class="block text-sm font-medium text-gray-700">Valeur maximum</label>
                 <input type="number"
-                       id="scale_max"
                        name="scale_max"
                        value="<%= @question.options&.dig('scale_max') || 5 %>"
+                       min="1"
+                       max="20"
                        class="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
                        data-action="input->question-form#updatePreview">
               </div>
+
               <div>
                 <label class="block text-sm font-medium text-gray-700">Pas</label>
                 <input type="number"
-                       id="scale_step"
                        name="scale_step"
                        value="<%= @question.options&.dig('scale_step') || 1 %>"
                        min="1"
@@ -181,22 +210,21 @@
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700">Label minimum (optionnel)</label>
+                <label class="block text-sm font-medium text-gray-700">Libellé minimum (optionnel)</label>
                 <input type="text"
-                       id="scale_min_label"
                        name="scale_min_label"
                        value="<%= @question.options&.dig('scale_min_label') %>"
-                       placeholder="ex: Pas du tout d'accord"
+                       placeholder="Ex: Très insatisfait"
                        class="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
                        data-action="input->question-form#updatePreview">
               </div>
+
               <div>
-                <label class="block text-sm font-medium text-gray-700">Label maximum (optionnel)</label>
+                <label class="block text-sm font-medium text-gray-700">Libellé maximum (optionnel)</label>
                 <input type="text"
-                       id="scale_max_label"
                        name="scale_max_label"
                        value="<%= @question.options&.dig('scale_max_label') %>"
-                       placeholder="ex: Tout à fait d'accord"
+                       placeholder="Ex: Très satisfait"
                        class="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
                        data-action="input->question-form#updatePreview">
               </div>
@@ -204,8 +232,8 @@
           </div>
 
           <div class="flex justify-end space-x-3">
-            <%= link_to "Annuler", admin_survey_path(@survey), class: "py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50" %>
-            <%= form.submit "Mettre à jour la question", class: "py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700" %>
+            <%= link_to "Annuler", admin_survey_path(@survey), class: "py-2 px-4 bg-white border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50" %>
+            <%= form.submit "Mettre à jour la question", class: "py-2 px-4 bg-green-600 border border-transparent rounded-md shadow-sm text-sm font-medium text-white hover:bg-green-700" %>
           </div>
         <% end %>
       </div>

--- a/app/views/admin/questions/new.html.erb
+++ b/app/views/admin/questions/new.html.erb
@@ -1,4 +1,3 @@
-<!-- app/views/admin/questions/new.html.erb -->
 <div class="py-6">
   <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex justify-between items-center mb-6">
@@ -83,7 +82,7 @@
                 } %>
               </div>
 
-              <%= render 'commune_location_info' if defined?(render) %>
+              <%= render 'commune_location_info' if defined?(@question) %>
 
               <%= render 'weekly_schedule_config' %>
 
@@ -141,6 +140,34 @@
               </svg>
               Ajouter une option
             </button>
+
+            <!-- Option "Autre" pour les questions de choix -->
+            <div data-question-form-target="otherOptionContainer" class="border border-gray-200 rounded-lg p-4 bg-gray-50">
+              <h4 class="font-medium text-gray-900 mb-3">Option "Autre"</h4>
+
+              <div class="flex items-center mb-3">
+                <%= check_box_tag :has_other_option, '1',
+                    @question.has_other_option?,
+                    class: "h-4 w-4 text-indigo-600 border-gray-300 rounded",
+                    data: {
+                      question_form_target: "otherOptionToggle",
+                      action: "change->question-form#toggleOtherOption"
+                    } %>
+                <%= label_tag :has_other_option, "Ajouter une option 'Autre' avec champ texte",
+                    class: "ml-2 text-sm text-gray-700" %>
+              </div>
+
+              <div data-question-form-target="otherTextLabelContainer"
+                   style="<%= @question.has_other_option? ? 'display: block;' : 'display: none;' %>">
+                <%= label_tag :other_text_label, "Libellé de l'option autre",
+                    class: "block text-sm font-medium text-gray-700 mb-1" %>
+                <%= text_field_tag :other_text_label,
+                    @question.options&.dig('other_text_label') || 'Autre (précisez)',
+                    class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
+                    data: { action: "input->question-form#updatePreview" } %>
+                <p class="mt-1 text-xs text-gray-500">Ce texte apparaîtra comme option dans le questionnaire</p>
+              </div>
+            </div>
           </div>
 
           <!-- Configuration pour les échelles -->
@@ -151,23 +178,28 @@
               <div>
                 <label class="block text-sm font-medium text-gray-700">Valeur minimum</label>
                 <input type="number"
-                       id="scale_min"
+                       name="scale_min"
                        value="1"
+                       min="0"
                        class="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
                        data-action="input->question-form#updatePreview">
               </div>
+
               <div>
                 <label class="block text-sm font-medium text-gray-700">Valeur maximum</label>
                 <input type="number"
-                       id="scale_max"
+                       name="scale_max"
                        value="5"
+                       min="1"
+                       max="20"
                        class="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
                        data-action="input->question-form#updatePreview">
               </div>
+
               <div>
                 <label class="block text-sm font-medium text-gray-700">Pas</label>
                 <input type="number"
-                       id="scale_step"
+                       name="scale_step"
                        value="1"
                        min="1"
                        class="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
@@ -177,18 +209,19 @@
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700">Label minimum (optionnel)</label>
+                <label class="block text-sm font-medium text-gray-700">Libellé minimum (optionnel)</label>
                 <input type="text"
-                       id="scale_min_label"
-                       placeholder="ex: Pas du tout d'accord"
+                       name="scale_min_label"
+                       placeholder="Ex: Très insatisfait"
                        class="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
                        data-action="input->question-form#updatePreview">
               </div>
+
               <div>
-                <label class="block text-sm font-medium text-gray-700">Label maximum (optionnel)</label>
+                <label class="block text-sm font-medium text-gray-700">Libellé maximum (optionnel)</label>
                 <input type="text"
-                       id="scale_max_label"
-                       placeholder="ex: Tout à fait d'accord"
+                       name="scale_max_label"
+                       placeholder="Ex: Très satisfait"
                        class="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
                        data-action="input->question-form#updatePreview">
               </div>
@@ -196,9 +229,9 @@
           </div>
 
           <div class="flex justify-end space-x-3">
-            <%= link_to "Annuler", admin_survey_path(@survey), class: "py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50" %>
-            <%= form.submit "Créer et ajouter une autre", name: "commit", class: "py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700" %>
-            <%= form.submit "Créer la question", class: "py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700" %>
+            <%= link_to "Annuler", admin_survey_path(@survey), class: "py-2 px-4 bg-white border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50" %>
+            <%= form.submit "Créer et ajouter une autre", name: "commit", class: "py-2 px-4 bg-indigo-600 border border-transparent rounded-md shadow-sm text-sm font-medium text-white hover:bg-indigo-700" %>
+            <%= form.submit "Créer la question", class: "py-2 px-4 bg-green-600 border border-transparent rounded-md shadow-sm text-sm font-medium text-white hover:bg-green-700" %>
           </div>
         <% end %>
       </div>

--- a/app/views/admin/surveys/preview.html.erb
+++ b/app/views/admin/surveys/preview.html.erb
@@ -86,124 +86,162 @@
                   <% end %>
                 </label>
 
-                <!-- Affichage selon le type de question -->
-                <% case question.question_type %>
-                <% when 'single_choice' %>
-                  <div class="space-y-2">
-                    <% question.question_options.each do |option| %>
-                      <label class="flex items-center">
-                        <input type="radio" name="question_<%= question.id %>" value="<%= option.value %>" class="h-4 w-4 text-indigo-600 border-gray-300">
-                        <span class="ml-2"><%= option.text %></span>
-                      </label>
-                    <% end %>
-                  </div>
+            <!-- Affichage selon le type de question -->
+            <% case question.question_type %>
+            <% when 'single_choice' %>
+              <div class="space-y-2">
+                <% question.question_options.each do |option| %>
+                  <label class="flex items-center p-2 hover:bg-gray-50 rounded cursor-pointer">
+                    <input type="radio" name="question_<%= question.id %>" value="<%= option.value %>" class="h-4 w-4 text-indigo-600 border-gray-300" disabled>
+                    <span class="ml-2"><%= option.text %></span>
+                  </label>
+                <% end %>
 
-                <% when 'multiple_choice' %>
-                  <div class="space-y-2">
-                    <% question.question_options.each do |option| %>
-                      <label class="flex items-center">
-                        <input type="checkbox" name="question_<%= question.id %>[]" value="<%= option.value %>" class="h-4 w-4 text-indigo-600 border-gray-300 rounded">
-                        <span class="ml-2"><%= option.text %></span>
-                      </label>
-                    <% end %>
-                  </div>
-
-                <% when 'ranking' %>
-                  <div class="space-y-3">
-                    <div class="bg-blue-50 p-3 rounded-md">
-                      <p class="text-sm text-blue-700">
-                        <i class="fas fa-info-circle"></i>
-                        Glissez-déposez les éléments pour les classer par ordre de priorité (prévisualisation)
-                      </p>
-                    </div>
-
-                    <div class="space-y-2 border border-gray-200 rounded-lg p-3">
-                      <% question.question_options.each_with_index do |option, index| %>
-                        <div class="bg-white border border-gray-300 rounded-lg p-3">
-                          <div class="flex items-center justify-between">
-                            <span class="font-medium"><%= option.text %></span>
-                            <div class="flex items-center space-x-2">
-                              <span class="bg-blue-100 text-blue-800 px-2 py-1 rounded-full text-sm font-bold"><%= index + 1 %></span>
-                              <i class="fas fa-grip-vertical text-gray-400"></i>
-                            </div>
-                          </div>
-                        </div>
-                      <% end %>
-                    </div>
-                  </div>
-
-
-                <% when 'weekly_schedule' %>
-                  <%= render 'weekly_schedule_preview', question: question %>
-
-                <% when 'scale' %>
-                  <div class="flex items-center justify-between">
-                    <% if question.options && question.options['scale_min_label'] %>
-                      <span class="text-sm text-gray-500"><%= question.options['scale_min_label'] %></span>
-                    <% end %>
-                    <div class="flex space-x-3">
-                      <% question.question_options.each do |option| %>
-                        <label class="flex flex-col items-center cursor-pointer">
-                          <input type="radio" name="question_<%= question.id %>" value="<%= option.value %>" class="h-4 w-4 text-indigo-600 border-gray-300">
-                          <span class="mt-1 text-sm"><%= option.text %></span>
-                        </label>
-                      <% end %>
-                    </div>
-                    <% if question.options && question.options['scale_max_label'] %>
-                      <span class="text-sm text-gray-500"><%= question.options['scale_max_label'] %></span>
-                    <% end %>
-                  </div>
-
-                <% when 'text' %>
-                  <input type="text" name="question_<%= question.id %>" class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="Votre réponse">
-
-                <% when 'long_text' %>
-                  <textarea name="question_<%= question.id %>" rows="4" class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="Votre réponse"></textarea>
-
-                <% when 'email' %>
-                  <input type="email" name="question_<%= question.id %>" class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="exemple@email.com">
-
-                <% when 'phone' %>
-                  <input type="tel" name="question_<%= question.id %>" class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="06 12 34 56 78">
-
-                <% when 'date' %>
-                  <input type="date" name="question_<%= question.id %>" class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
-
-                <% when 'numeric' %>
-                  <input type="number" name="question_<%= question.id %>" class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="0">
-
-                <% when 'yes_no' %>
-                  <div class="flex space-x-4">
-                    <label class="flex items-center">
-                      <input type="radio" name="question_<%= question.id %>" value="yes" class="h-4 w-4 text-indigo-600 border-gray-300">
-                      <span class="ml-2">Oui</span>
-                    </label>
-                    <label class="flex items-center">
-                      <input type="radio" name="question_<%= question.id %>" value="no" class="h-4 w-4 text-indigo-600 border-gray-300">
-                      <span class="ml-2">Non</span>
-                    </label>
+                <% if question.has_other_option? %>
+                  <label class="flex items-center p-2 hover:bg-gray-50 rounded cursor-pointer">
+                    <input type="radio" name="question_<%= question.id %>" value="other" class="h-4 w-4 text-indigo-600 border-gray-300" disabled>
+                    <span class="ml-2"><%= question.options&.dig('other_text_label') || 'Autre (précisez)' %></span>
+                  </label>
+                  <div class="ml-6 mt-2">
+                    <input type="text" placeholder="Veuillez préciser..." class="w-full rounded-md border-gray-300 shadow-sm text-sm" disabled>
                   </div>
                 <% end %>
               </div>
+
+            <% when 'multiple_choice' %>
+              <div class="space-y-2">
+                <% question.question_options.each do |option| %>
+                  <label class="flex items-center p-2 hover:bg-gray-50 rounded cursor-pointer">
+                    <input type="checkbox" name="question_<%= question.id %>[]" value="<%= option.value %>" class="h-4 w-4 text-indigo-600 border-gray-300 rounded" disabled>
+                    <span class="ml-2"><%= option.text %></span>
+                  </label>
+                <% end %>
+
+                <% if question.has_other_option? %>
+                  <label class="flex items-center p-2 hover:bg-gray-50 rounded cursor-pointer">
+                    <input type="checkbox" name="question_<%= question.id %>[]" value="other" class="h-4 w-4 text-indigo-600 border-gray-300 rounded" disabled>
+                    <span class="ml-2"><%= question.options&.dig('other_text_label') || 'Autre (précisez)' %></span>
+                  </label>
+                  <div class="ml-6 mt-2">
+                    <input type="text" placeholder="Veuillez préciser..." class="w-full rounded-md border-gray-300 shadow-sm text-sm" disabled>
+                  </div>
+                <% end %>
+              </div>
+
+            <% when 'ranking' %>
+              <div class="space-y-3">
+                <div class="bg-blue-50 p-3 rounded-md">
+                  <p class="text-sm text-blue-700">
+                    <i class="fas fa-info-circle"></i>
+                    Glissez-déposez les éléments pour les classer par ordre de priorité (prévisualisation)
+                  </p>
+                </div>
+
+                <div class="space-y-2 border border-gray-200 rounded-lg p-3">
+                  <% question.question_options.each_with_index do |option, index| %>
+                    <div class="bg-white border border-gray-300 rounded-lg p-3">
+                      <div class="flex items-center justify-between">
+                        <span class="font-medium"><%= option.text %></span>
+                        <div class="flex items-center space-x-2">
+                          <span class="bg-blue-100 text-blue-800 px-2 py-1 rounded-full text-sm font-bold"><%= index + 1 %></span>
+                          <i class="fas fa-grip-vertical text-gray-400"></i>
+                        </div>
+                      </div>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+
+            <% when 'weekly_schedule' %>
+              <%= render 'weekly_schedule_preview', question: question %>
+
+            <% when 'scale' %>
+              <div class="flex items-center justify-between">
+                <% if question.options && question.options['scale_min_label'] %>
+                  <span class="text-sm text-gray-500"><%= question.options['scale_min_label'] %></span>
+                <% end %>
+                <div class="flex space-x-3">
+                  <% question.question_options.each do |option| %>
+                    <label class="flex flex-col items-center cursor-pointer group">
+                      <input type="radio" name="question_<%= question.id %>" value="<%= option.value %>" class="h-4 w-4 text-indigo-600 border-gray-300" disabled>
+                      <span class="mt-1 text-sm group-hover:text-indigo-600"><%= option.text %></span>
+                    </label>
+                  <% end %>
+                </div>
+                <% if question.options && question.options['scale_max_label'] %>
+                  <span class="text-sm text-gray-500"><%= question.options['scale_max_label'] %></span>
+                <% end %>
+              </div>
+
+            <% when 'text' %>
+              <input type="text" class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="Votre réponse" disabled>
+
+            <% when 'long_text' %>
+              <textarea rows="4" class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="Votre réponse" disabled></textarea>
+
+            <% when 'email' %>
+              <input type="email" class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="exemple@email.com" disabled>
+
+            <% when 'phone' %>
+              <input type="tel" class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="06 12 34 56 78" disabled>
+
+            <% when 'date' %>
+              <input type="date" class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" disabled>
+
+            <% when 'numeric' %>
+              <input type="number" class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="0" disabled>
+
+            <% when 'yes_no' %>
+              <div class="flex space-x-4">
+                <label class="flex items-center">
+                  <input type="radio" name="question_<%= question.id %>" value="yes" class="h-4 w-4 text-indigo-600 border-gray-300" disabled>
+                  <span class="ml-2">Oui</span>
+                </label>
+                <label class="flex items-center">
+                  <input type="radio" name="question_<%= question.id %>" value="no" class="h-4 w-4 text-indigo-600 border-gray-300" disabled>
+                  <span class="ml-2">Non</span>
+                </label>
+              </div>
+
+            <% when 'commune_location' %>
+              <select class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" disabled>
+                <option>Sélectionnez votre commune...</option>
+                <option>Exemple Commune 1</option>
+                <option>Exemple Commune 2</option>
+                <option>Autre commune</option>
+              </select>
+
+            <% else %>
+              <p class="text-gray-500 italic">Type de question non supporté en prévisualisation</p>
             <% end %>
           </div>
         <% end %>
+      </div>
+    <% end %>
 
-        <!-- Message de fin de prévisualisation -->
-        <div class="bg-gray-50 rounded-lg p-4 text-center">
-          <p class="text-gray-600">Fin de la prévisualisation</p>
-          <% if @survey.thank_you_message.present? %>
-            <div class="mt-4 p-4 bg-green-50 rounded">
-              <p class="text-green-800"><%= @survey.thank_you_message %></p>
-            </div>
-          <% end %>
+    <!-- Message de fin -->
+    <% if @survey.thank_you_message.present? %>
+      <div class="bg-white rounded-lg shadow-sm p-6">
+        <div class="p-4 bg-green-50 rounded-lg">
+          <h3 class="text-green-800 font-medium mb-2">Message de remerciement</h3>
+          <p class="text-green-700"><%= @survey.thank_you_message %></p>
         </div>
+      </div>
+    <% end %>
 
-        <!-- Boutons d'action -->
-        <div class="flex justify-center space-x-4 pt-6">
-          <button type="button" onclick="window.close()" class="px-6 py-2 border border-gray-300 rounded-md text-gray-700 bg-white hover:bg-gray-50">
-            Fermer la prévisualisation
-          </button>
+    <!-- Actions -->
+    <div class="mt-8 text-center">
+      <div class="bg-white rounded-lg shadow-sm p-6">
+        <p class="text-gray-600 mb-4">Ceci est une prévisualisation de votre enquête.</p>
+        <div class="space-x-4">
+          <%= link_to "Retour à l'édition", admin_survey_path(@survey),
+              class: "inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50" %>
+          <% unless @survey.published? %>
+            <%= link_to "Publier l'enquête", publish_admin_survey_path(@survey),
+                method: :patch,
+                data: { confirm: "Êtes-vous sûr de vouloir publier cette enquête ?" },
+                class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700" %>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/public_surveys/show.html.erb
+++ b/app/views/public_surveys/show.html.erb
@@ -1,249 +1,268 @@
 <!-- app/views/public_surveys/show.html.erb -->
-<div class="min-h-screen bg-gray-50 py-12">
+<div class="min-h-screen bg-gray-50 py-8">
   <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
-    <div class="bg-white shadow-lg rounded-lg">
-      <!-- En-tête -->
-      <div class="bg-gradient-to-r from-indigo-500 to-purple-600 text-white p-6 rounded-t-lg">
-        <h1 class="text-2xl font-bold"><%= @survey.title %></h1>
-        <% if @survey.description.present? %>
-          <p class="mt-2 text-indigo-100"><%= @survey.description %></p>
-        <% end %>
+    <!-- En-tête de l'enquête -->
+    <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
+      <h1 class="text-2xl font-bold text-gray-900 mb-2"><%= @survey.title %></h1>
+      <% if @survey.description.present? %>
+        <p class="text-gray-600"><%= @survey.description %></p>
+      <% end %>
+    </div>
+
+    <!-- Barre de progression -->
+    <% if @survey.show_progress_bar? %>
+      <div class="bg-white rounded-lg shadow-sm p-4 mb-6">
+        <div class="flex justify-between text-sm text-gray-600 mb-2">
+          <span>Progression</span>
+          <span><%= @current_section_index + 1 %>/<%= @sections.count %></span>
+        </div>
+        <div class="w-full bg-gray-200 rounded-full h-2">
+          <div class="bg-indigo-600 h-2 rounded-full" style="width: <%= ((@current_section_index + 1).to_f / @sections.count * 100).round %>%"></div>
+        </div>
       </div>
+    <% end %>
 
-      <!-- Message d'accueil -->
-      <% if @user_survey.welcome_message.present? %>
-        <div class="p-6 border-b bg-blue-50">
-          <div class="flex items-start">
-            <svg class="h-5 w-5 text-blue-400 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            <p class="ml-3 text-gray-700"><%= @user_survey.welcome_message %></p>
-          </div>
-        </div>
-      <% end %>
+    <!-- Formulaire de section -->
+    <%= form_with url: submit_section_public_survey_path(@user_survey.public_token),
+                  method: :post,
+                  local: true,
+                  class: "bg-white rounded-lg shadow-sm p-6",
+                  data: { controller: "other-option" } do |form| %>
 
-      <!-- Barre de progression -->
-      <% if @survey.show_progress_bar? %>
-        <% current_section_index = params[:section] ? @sections.find_index { |s| s.id.to_s == params[:section] } || 0 : 0 %>
-        <% progress = ((current_section_index + 1).to_f / @sections.count * 100).round %>
-        <div class="px-6 pt-6">
-          <div class="flex justify-between text-sm text-gray-600 mb-2">
-            <span>Progression</span>
-            <span><%= progress %>%</span>
-          </div>
-          <div class="w-full bg-gray-200 rounded-full h-2">
-            <div class="bg-indigo-600 h-2 rounded-full transition-all duration-300" style="width: <%= progress %>%"></div>
-          </div>
-        </div>
-      <% end %>
+      <%= hidden_field_tag :section_id, @current_section.id %>
 
-      <!-- Formulaire -->
-      <%= form_with url: submit_section_public_survey_path(@user_survey.public_token), local: true, class: "p-6" do |form| %>
-        <% current_section = @sections[current_section_index] %>
-        <%= hidden_field_tag :section_id, current_section.id %>
-
-        <!-- Section -->
-        <div class="mb-8">
-          <h2 class="text-xl font-semibold text-gray-900 mb-2">
-            <%= current_section.title %>
-            <% if current_section.required? %>
-              <span class="text-sm text-red-500 ml-2">*Section obligatoire</span>
-            <% end %>
-          </h2>
-          <% if current_section.description.present? %>
-            <p class="text-gray-600"><%= current_section.description %></p>
+      <!-- Titre de section -->
+      <% unless @current_section.title == "Section par défaut" %>
+        <div class="mb-6 pb-4 border-b border-gray-200">
+          <h2 class="text-xl font-semibold text-gray-900"><%= @current_section.title %></h2>
+          <% if @current_section.description.present? %>
+            <p class="text-gray-600"><%= @current_section.description %></p>
           <% end %>
         </div>
+      <% end %>
 
-        <!-- Questions -->
-        <div class="space-y-6">
-          <% current_section.questions.each_with_index do |question, index| %>
-            <div class="bg-gray-50 rounded-lg p-4">
-              <label class="block mb-3">
-                <span class="text-gray-700 font-medium">
-                  <%= index + 1 %>. <%= question.title %>
-                  <% if question.required? %>
-                    <span class="text-red-500">*</span>
-                  <% end %>
-                </span>
-                <% if question.description.present? %>
-                  <p class="text-sm text-gray-500 mt-1"><%= question.description %></p>
+      <!-- Questions -->
+      <div class="space-y-6">
+        <% @current_section.questions.each_with_index do |question, index| %>
+          <div class="bg-gray-50 rounded-lg p-4">
+            <label class="block mb-3">
+              <span class="text-gray-700 font-medium">
+                <%= index + 1 %>. <%= question.title %>
+                <% if question.required? %>
+                  <span class="text-red-500">*</span>
                 <% end %>
-              </label>
+              </span>
+              <% if question.description.present? %>
+                <p class="text-sm text-gray-500 mt-1"><%= question.description %></p>
+              <% end %>
+            </label>
 
-              <div class="mt-3">
-                <% case question.question_type %>
-                <% when 'single_choice' %>
-                  <div class="space-y-2">
+            <div class="mt-3">
+              <% case question.question_type %>
+              <% when 'single_choice' %>
+                <div class="space-y-2">
+                  <% question.question_options.each do |option| %>
+                    <label class="flex items-center p-2 hover:bg-gray-100 rounded cursor-pointer">
+                      <%= radio_button_tag "responses[#{question.id}]", option.value, false,
+                          class: "h-4 w-4 text-indigo-600 border-gray-300",
+                          required: question.required? %>
+                      <span class="ml-2"><%= option.text %></span>
+                    </label>
+                  <% end %>
+
+                  <% if question.has_other_option? %>
+                    <label class="flex items-center p-2 hover:bg-gray-100 rounded cursor-pointer">
+                      <%= radio_button_tag "responses[#{question.id}]", 'other', false,
+                          class: "h-4 w-4 text-indigo-600 border-gray-300",
+                          required: question.required?,
+                          data: {
+                            other_option_target: "trigger",
+                            question_id: question.id,
+                            action: "change->other-option#toggleOtherInput"
+                          } %>
+                      <span class="ml-2"><%= question.options&.dig('other_text_label') || 'Autre (précisez)' %></span>
+                    </label>
+
+                    <div class="ml-6 mt-2" style="display: none;"
+                         data-other-option-target="input"
+                         data-question-id="<%= question.id %>">
+                      <%= text_field_tag "responses[#{question.id}_other_text]", nil,
+                          placeholder: "Veuillez préciser...",
+                          class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm" %>
+                    </div>
+                  <% end %>
+                </div>
+
+              <% when 'multiple_choice' %>
+                <div class="space-y-2">
+                  <% question.question_options.each do |option| %>
+                    <label class="flex items-center p-2 hover:bg-gray-100 rounded cursor-pointer">
+                      <%= check_box_tag "responses[#{question.id}][]", option.value, false,
+                          class: "h-4 w-4 text-indigo-600 border-gray-300 rounded" %>
+                      <span class="ml-2"><%= option.text %></span>
+                    </label>
+                  <% end %>
+
+                  <% if question.has_other_option? %>
+                    <label class="flex items-center p-2 hover:bg-gray-100 rounded cursor-pointer">
+                      <%= check_box_tag "responses[#{question.id}][]", 'other', false,
+                          class: "h-4 w-4 text-indigo-600 border-gray-300 rounded",
+                          data: {
+                            other_option_target: "trigger",
+                            question_id: question.id,
+                            action: "change->other-option#toggleOtherInput"
+                          } %>
+                      <span class="ml-2"><%= question.options&.dig('other_text_label') || 'Autre (précisez)' %></span>
+                    </label>
+
+                    <div class="ml-6 mt-2" style="display: none;"
+                         data-other-option-target="input"
+                         data-question-id="<%= question.id %>">
+                      <%= text_field_tag "responses[#{question.id}_other_text]", nil,
+                          placeholder: "Veuillez préciser...",
+                          class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm" %>
+                    </div>
+                  <% end %>
+                </div>
+
+              <% when 'ranking' %>
+                <div data-controller="ranking-question" data-ranking-question-name="responses[<%= question.id %>]">
+                  <div class="bg-blue-50 border border-blue-200 p-4 rounded-lg mb-4">
+                    <div class="flex items-center">
+                      <svg class="h-5 w-5 text-blue-500 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                      <p class="text-sm text-blue-700">
+                        Glissez et déposez les éléments pour les classer par ordre de priorité (1 = le plus important).
+                      </p>
+                    </div>
+                  </div>
+
+                  <div data-ranking-question-target="container" class="space-y-2">
+                    <% question.question_options.each_with_index do |option, idx| %>
+                      <div class="ranking-item bg-white border border-gray-300 rounded-lg p-3 cursor-move hover:border-indigo-300 transition-colors"
+                           data-ranking-question-target="item"
+                           data-value="<%= option.value %>"
+                           draggable="true">
+                        <div class="flex items-center">
+                          <svg class="h-5 w-5 text-gray-400 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />
+                          </svg>
+                          <span class="font-medium text-gray-700 ranking-position mr-3"><%= idx + 1 %>.</span>
+                          <span class="text-gray-900"><%= option.text %></span>
+                        </div>
+                      </div>
+                    <% end %>
+                  </div>
+
+                  <!-- Hidden inputs pour stocker l'ordre -->
+                  <div data-ranking-question-target="hiddenInputs">
+                    <!-- Les inputs seront générés dynamiquement par le controller JS -->
+                  </div>
+                </div>
+
+              <% when 'scale' %>
+                <div class="flex items-center justify-between mt-4">
+                  <% if question.options && question.options['scale_min_label'] %>
+                    <span class="text-sm text-gray-500"><%= question.options['scale_min_label'] %></span>
+                  <% end %>
+                  <div class="flex space-x-3">
                     <% question.question_options.each do |option| %>
-                      <label class="flex items-center p-2 hover:bg-gray-100 rounded cursor-pointer">
+                      <label class="flex flex-col items-center cursor-pointer group">
                         <%= radio_button_tag "responses[#{question.id}]", option.value, false,
                             class: "h-4 w-4 text-indigo-600 border-gray-300",
                             required: question.required? %>
-                        <span class="ml-2"><%= option.text %></span>
+                        <span class="mt-1 text-sm group-hover:text-indigo-600"><%= option.text %></span>
                       </label>
                     <% end %>
                   </div>
+                  <% if question.options && question.options['scale_max_label'] %>
+                    <span class="text-sm text-gray-500"><%= question.options['scale_max_label'] %></span>
+                  <% end %>
+                </div>
 
-                <% when 'multiple_choice' %>
-                  <div class="space-y-2">
-                    <% question.question_options.each do |option| %>
-                      <label class="flex items-center p-2 hover:bg-gray-100 rounded cursor-pointer">
-                        <%= check_box_tag "responses[#{question.id}][#{option.value}]", option.value, false,
-                            class: "h-4 w-4 text-indigo-600 border-gray-300 rounded" %>
-                        <span class="ml-2"><%= option.text %></span>
-                      </label>
-                    <% end %>
-                  </div>
+              <% when 'text' %>
+                <%= text_field_tag "responses[#{question.id}]", nil,
+                    class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
+                    placeholder: "Votre réponse",
+                    required: question.required? %>
 
-                <% when 'ranking' %>
-                  <div data-controller="ranking-question" data-ranking-question-name="responses[<%= question.id %>]">
-                    <div class="bg-blue-50 border border-blue-200 p-4 rounded-lg mb-4">
-                      <div class="flex items-center">
-                        <svg class="h-5 w-5 text-blue-500 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
-                        </svg>
-                        <p class="text-sm text-blue-700 font-medium">
-                          Glissez-déposez les éléments pour les classer par ordre de priorité
-                        </p>
-                      </div>
-                      <p class="text-xs text-blue-600 mt-1 ml-7">1er = plus important • Dernière position = moins important</p>
-                    </div>
+              <% when 'long_text' %>
+                <%= text_area_tag "responses[#{question.id}]", nil,
+                    rows: 4,
+                    class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
+                    placeholder: "Votre réponse",
+                    required: question.required? %>
 
-                    <div data-ranking-question-target="sortableList" class="space-y-3 bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg p-4">
-                      <% question.question_options.each_with_index do |option, index| %>
-                        <div class="ranking-item bg-white border-2 border-gray-200 rounded-lg p-4 shadow-sm"
-                             data-option-value="<%= option.value %>"
-                             data-ranking-question-target="item">
-                          <div class="flex items-center justify-between">
-                            <div class="flex items-center flex-1">
-                              <div class="ranking-grip mr-3 text-gray-400">
-                                <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l4-4 4 4m0 6l-4 4-4-4" />
-                                </svg>
-                              </div>
-                              <span class="font-medium text-gray-800 flex-1"><%= option.text %></span>
-                            </div>
-                            <div class="flex items-center space-x-2">
-                              <span class="text-xs text-gray-500 font-medium">Position</span>
-                              <span class="ranking-number bg-indigo-500 text-white px-3 py-1 rounded-full text-sm font-bold min-w-[2rem] text-center"
-                                    data-ranking-question-target="rankNumber"><%= index + 1 %></span>
-                            </div>
-                          </div>
-                        </div>
-                      <% end %>
-                    </div>
+              <% when 'email' %>
+                <%= email_field_tag "responses[#{question.id}]", nil,
+                    class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
+                    placeholder: "exemple@email.com",
+                    required: question.required? %>
 
-                    <!-- Champ caché pour stocker l'ordre -->
-                    <input type="hidden"
-                           name="responses[<%= question.id %>]"
-                           data-ranking-question-target="hiddenInput"
-                           <% if question.required? %>required<% end %>>
-                  </div>
+              <% when 'phone' %>
+                <%= telephone_field_tag "responses[#{question.id}]", nil,
+                    class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
+                    placeholder: "06 12 34 56 78",
+                    required: question.required? %>
 
-                <% when 'scale' %>
-                  <div class="flex items-center justify-between mt-4">
-                    <% if question.options && question.options['scale_min_label'] %>
-                      <span class="text-sm text-gray-500"><%= question.options['scale_min_label'] %></span>
-                    <% end %>
-                    <div class="flex space-x-3">
-                      <% question.question_options.each do |option| %>
-                        <label class="flex flex-col items-center cursor-pointer group">
-                          <%= radio_button_tag "responses[#{question.id}]", option.value, false,
-                              class: "h-4 w-4 text-indigo-600 border-gray-300",
-                              required: question.required? %>
-                          <span class="mt-1 text-sm group-hover:text-indigo-600"><%= option.text %></span>
-                        </label>
-                      <% end %>
-                    </div>
-                    <% if question.options && question.options['scale_max_label'] %>
-                      <span class="text-sm text-gray-500"><%= question.options['scale_max_label'] %></span>
-                    <% end %>
-                  </div>
+              <% when 'date' %>
+                <%= date_field_tag "responses[#{question.id}]", nil,
+                    class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
+                    required: question.required? %>
 
-                <% when 'text' %>
-                  <%= text_field_tag "responses[#{question.id}]", nil,
-                      class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
-                      placeholder: "Votre réponse",
-                      required: question.required? %>
+              <% when 'numeric' %>
+                <%= number_field_tag "responses[#{question.id}]", nil,
+                    class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
+                    placeholder: "0",
+                    required: question.required? %>
 
-                <% when 'long_text' %>
-                  <%= text_area_tag "responses[#{question.id}]", nil,
-                      rows: 4,
-                      class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
-                      placeholder: "Votre réponse",
-                      required: question.required? %>
+              <% when 'commune_location' %>
+                <%= render 'commune_location_question', question: question %>
 
-                <% when 'email' %>
-                  <%= email_field_tag "responses[#{question.id}]", nil,
-                      class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
-                      placeholder: "exemple@email.com",
-                      required: question.required? %>
+              <% when 'weekly_schedule' %>
+                <%= render 'weekly_schedule_question', question: question %>
 
-                <% when 'phone' %>
-                  <%= telephone_field_tag "responses[#{question.id}]", nil,
-                      class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
-                      placeholder: "06 12 34 56 78",
-                      required: question.required? %>
-
-                <% when 'date' %>
-                  <%= date_field_tag "responses[#{question.id}]", nil,
-                      class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
-                      required: question.required? %>
-
-                <% when 'numeric' %>
-                  <%= number_field_tag "responses[#{question.id}]", nil,
-                      class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
-                      placeholder: "0",
-                      required: question.required? %>
-
-                <% when 'commune_location' %>
-                  <%= render 'commune_location_question', question: question %>
-
-                <% when 'weekly_schedule' %>
-                  <%= render 'weekly_schedule_question', question: question %>
-
-                <% when 'yes_no' %>
-                  <div class="flex space-x-4">
-                    <label class="flex items-center">
-                      <%= radio_button_tag "responses[#{question.id}]", "yes", false,
-                          class: "h-4 w-4 text-indigo-600 border-gray-300",
-                          required: question.required? %>
-                      <span class="ml-2">Oui</span>
-                    </label>
-                    <label class="flex items-center">
-                      <%= radio_button_tag "responses[#{question.id}]", "no", false,
-                          class: "h-4 w-4 text-indigo-600 border-gray-300",
-                          required: question.required? %>
-                      <span class="ml-2">Non</span>
-                    </label>
-                  </div>
-                <% end %>
-              </div>
+              <% when 'yes_no' %>
+                <div class="flex space-x-4">
+                  <label class="flex items-center">
+                    <%= radio_button_tag "responses[#{question.id}]", "yes", false,
+                        class: "h-4 w-4 text-indigo-600 border-gray-300",
+                        required: question.required? %>
+                    <span class="ml-2">Oui</span>
+                  </label>
+                  <label class="flex items-center">
+                    <%= radio_button_tag "responses[#{question.id}]", "no", false,
+                        class: "h-4 w-4 text-indigo-600 border-gray-300",
+                        required: question.required? %>
+                    <span class="ml-2">Non</span>
+                  </label>
+                </div>
+              <% end %>
             </div>
-          <% end %>
-        </div>
+          </div>
+        <% end %>
+      </div>
 
-        <!-- Navigation -->
-        <div class="mt-8 flex justify-between">
-          <% if current_section_index > 0 %>
-            <% prev_section = @sections[current_section_index - 1] %>
-            <%= link_to public_survey_path(@user_survey.public_token, section: prev_section.id),
-                class: "px-6 py-2 border border-gray-300 rounded-md text-gray-700 bg-white hover:bg-gray-50" do %>
-              ← Précédent
-            <% end %>
-          <% else %>
-            <div></div>
+      <!-- Navigation -->
+      <div class="mt-8 flex justify-between">
+        <% if @current_section_index > 0 %>
+          <% prev_section = @sections[@current_section_index - 1] %>
+          <%= link_to public_survey_path(@user_survey.public_token, section: prev_section.id),
+              class: "px-6 py-2 border border-gray-300 rounded-md text-gray-700 bg-white hover:bg-gray-50" do %>
+            ← Précédent
           <% end %>
+        <% else %>
+          <div></div>
+        <% end %>
 
-          <% if current_section_index < @sections.count - 1 %>
-            <%= form.submit "Suivant →", class: "px-6 py-2 border border-transparent rounded-md text-white bg-indigo-600 hover:bg-indigo-700" %>
-          <% else %>
-            <%= form.submit "Terminer", class: "px-6 py-2 border border-transparent rounded-md text-white bg-green-600 hover:bg-green-700" %>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
+        <% if @current_section_index < @sections.count - 1 %>
+          <%= form.submit "Suivant →", class: "px-6 py-2 border border-transparent rounded-md text-white bg-indigo-600 hover:bg-indigo-700" %>
+        <% else %>
+          <%= form.submit "Terminer", class: "px-6 py-2 border border-transparent rounded-md text-white bg-green-600 hover:bg-green-700" %>
+        <% end %>
+      </div>
+    <% end %>
 
     <!-- Footer -->
     <div class="mt-6 text-center text-sm text-gray-500">

--- a/app/views/user_surveys/results.html.erb
+++ b/app/views/user_surveys/results.html.erb
@@ -185,59 +185,116 @@
                 <% stats = @statistics[question.id] %>
                 <% if stats %>
                   <% case question.question_type %>
-                  <% when 'single_choice', 'yes_no' %>
-                    <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-                      <div>
-                        <% if stats.is_a?(Hash) && stats.any? %>
-                          <% total_responses = stats.values.sum %>
-                          <div class="space-y-3">
-                            <% stats.sort_by { |_, count| -count }.each do |answer, count| %>
-                              <% percentage = (count.to_f / total_responses * 100).round(1) %>
-                              <div class="relative">
-                                <div class="flex justify-between items-center mb-1">
-                                  <span class="text-sm font-medium text-gray-700">
-                                    <% if question.question_type == 'yes_no' %>
-                                      <%= answer == 'yes' ? 'Oui' : 'Non' %>
-                                    <% else %>
-                                      <%= question.question_options.find { |o| o.value == answer }&.text || answer %>
-                                    <% end %>
-                                  </span>
-                                  <span class="text-sm text-gray-600">
-                                    <%= count %> (<%= percentage %>%)
-                                  </span>
-                                </div>
-                                <div class="w-full bg-gray-200 rounded-full h-8 overflow-hidden">
-                                  <div class="h-full bg-gradient-to-r from-indigo-500 to-purple-600 rounded-full flex items-center justify-end pr-3 transition-all duration-500"
-                                       style="width: <%= percentage %>%">
-                                    <span class="text-white text-xs font-medium"><%= percentage %>%</span>
+                    <% when 'single_choice', 'yes_no' %>
+                      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+                        <div>
+                          <% if stats.is_a?(Hash) && stats.any? %>
+                            <% total_responses = stats.values.sum %>
+                            <div class="space-y-3">
+                              <%
+                                # Séparer les réponses "autre" des réponses normales
+                                other_count = stats['other'] || 0
+                                normal_stats = stats.except('other')
+                              %>
+
+                              <% normal_stats.sort_by { |_, count| -count }.each do |answer, count| %>
+                                <% percentage = (count.to_f / total_responses * 100).round(1) %>
+                                <div class="relative">
+                                  <div class="flex justify-between items-center mb-1">
+                                    <span class="text-sm font-medium text-gray-700">
+                                      <% if question.question_type == 'yes_no' %>
+                                        <%= answer == 'yes' ? 'Oui' : 'Non' %>
+                                      <% else %>
+                                        <%= question.question_options.find { |o| o.value == answer }&.text || answer %>
+                                      <% end %>
+                                    </span>
+                                    <span class="text-sm text-gray-600">
+                                      <%= count %> (<%= percentage %>%)
+                                    </span>
+                                  </div>
+                                  <div class="w-full bg-gray-200 rounded-full h-8 overflow-hidden">
+                                    <div class="h-full bg-gradient-to-r from-indigo-500 to-purple-600 rounded-full flex items-center justify-end pr-3 transition-all duration-500"
+                                         style="width: <%= percentage %>%">
+                                      <span class="text-white text-xs font-medium"><%= percentage %>%</span>
+                                    </div>
                                   </div>
                                 </div>
-                              </div>
-                            <% end %>
+                              <% end %>
+
+                              <!-- Affichage des réponses "autre" si présentes -->
+                              <% if other_count > 0 %>
+                                <% other_percentage = (other_count.to_f / total_responses * 100).round(1) %>
+                                <div class="relative">
+                                  <div class="flex justify-between items-center mb-1">
+                                    <span class="text-sm font-medium text-gray-700">
+                                      <%= question.options&.dig('other_text_label') || 'Autre' %>
+                                    </span>
+                                    <span class="text-sm text-gray-600">
+                                      <%= other_count %> (<%= other_percentage %>%)
+                                    </span>
+                                  </div>
+                                  <div class="w-full bg-gray-200 rounded-full h-8 overflow-hidden">
+                                    <div class="h-full bg-gradient-to-r from-orange-500 to-red-600 rounded-full flex items-center justify-end pr-3 transition-all duration-500"
+                                         style="width: <%= other_percentage %>%">
+                                      <span class="text-white text-xs font-medium"><%= other_percentage %>%</span>
+                                    </div>
+                                  </div>
+                                </div>
+
+                                <!-- Détail des réponses "autre" -->
+                                <%
+                                  # Récupérer les textes des réponses "autre" depuis la base de données
+                                  # CORRECTION: Utiliser une requête compatible PostgreSQL
+                                  other_responses = @user_survey.survey_responses.completed
+                                                    .joins(:question_responses)
+                                                    .where(question_responses: { question: question, answer_text: 'other' })
+                                                    .where.not(question_responses: { answer_data: nil })
+                                                    .includes(:question_responses)
+                                                    .map { |sr| sr.question_responses.find { |qr| qr.question_id == question.id } }
+                                                    .map { |qr| qr.answer_data.is_a?(Hash) ? qr.answer_data['text'] : nil }
+                                                    .compact
+                                                    .reject(&:blank?)
+                                %>
+
+                                <% if other_responses.any? %>
+                                  <div class="ml-4 mt-3 p-3 bg-orange-50 rounded-lg border border-orange-200">
+                                    <h5 class="text-sm font-medium text-orange-800 mb-2">Détail des réponses "Autre" :</h5>
+                                    <div class="space-y-1">
+                                      <% other_responses.each do |response_text| %>
+                                        <div class="text-xs text-orange-700 bg-orange-100 px-2 py-1 rounded inline-block mr-1 mb-1">
+                                          "<%= truncate(response_text, length: 50) %>"
+                                        </div>
+                                      <% end %>
+                                    </div>
+                                  </div>
+                                <% end %>
+                              <% end %>
+                            </div>
+                          <% else %>
+                            <p class="text-gray-500 italic">Aucune réponse</p>
+                          <% end %>
+                        </div>
+                        <div class="flex items-center justify-center">
+                          <div class="w-full max-w-xs">
+                            <canvas data-survey-results-target="chart"
+                                    data-chart-type="doughnut"
+                                    data-question-id="<%= question.id %>"
+                                    data-chart-data="<%= {
+                                      labels: stats.map { |answer, _|
+                                        if answer == 'other'
+                                          question.options&.dig('other_text_label') || 'Autre'
+                                        elsif question.question_type == 'yes_no'
+                                          answer == 'yes' ? 'Oui' : 'Non'
+                                        else
+                                          question.question_options.find { |o| o.value == answer }&.text || answer
+                                        end
+                                      },
+                                      values: stats.values
+                                    }.to_json %>"
+                                    class="max-h-64"></canvas>
                           </div>
-                        <% else %>
-                          <p class="text-gray-500 italic">Aucune réponse</p>
-                        <% end %>
-                      </div>
-                      <div class="flex items-center justify-center">
-                        <div class="w-full max-w-xs">
-                          <canvas data-survey-results-target="chart"
-                                  data-chart-type="doughnut"
-                                  data-question-id="<%= question.id %>"
-                                  data-chart-data="<%= {
-                                    labels: stats.map { |answer, _|
-                                      if question.question_type == 'yes_no'
-                                        answer == 'yes' ? 'Oui' : 'Non'
-                                      else
-                                        question.question_options.find { |o| o.value == answer }&.text || answer
-                                      end
-                                    },
-                                    values: stats.values
-                                  }.to_json %>"
-                                  class="max-h-64"></canvas>
                         </div>
                       </div>
-                    </div>
 
                   <% when 'ranking' %>
                     <% if stats && stats[:total_responses] > 0 %>
@@ -340,7 +397,13 @@
                         <% if stats.is_a?(Hash) && stats.any? %>
                           <% total_responses = @user_survey.response_count %>
                           <div class="space-y-3">
-                            <% stats.sort_by { |_, count| -count }.each do |answer, count| %>
+                            <%
+                              # Séparer les réponses "autre" des réponses normales
+                              other_count = stats['other'] || 0
+                              normal_stats = stats.except('other')
+                            %>
+
+                            <% normal_stats.sort_by { |_, count| -count }.each do |answer, count| %>
                               <% percentage = (count.to_f / total_responses * 100).round(1) %>
                               <div class="relative">
                                 <div class="flex justify-between items-center mb-1">
@@ -359,6 +422,64 @@
                                 </div>
                               </div>
                             <% end %>
+
+                            <!-- Affichage des réponses "autre" si présentes -->
+                            <% if other_count > 0 %>
+                              <% other_percentage = (other_count.to_f / total_responses * 100).round(1) %>
+                              <div class="relative">
+                                <div class="flex justify-between items-center mb-1">
+                                  <span class="text-sm font-medium text-gray-700">
+                                    <%= question.options&.dig('other_text_label') || 'Autre' %>
+                                  </span>
+                                  <span class="text-sm text-gray-600">
+                                    <%= other_count %> (<%= other_percentage %>%)
+                                  </span>
+                                </div>
+                                <div class="w-full bg-gray-200 rounded-full h-8 overflow-hidden">
+                                  <div class="h-full bg-gradient-to-r from-orange-500 to-red-600 rounded-full flex items-center justify-end pr-3 transition-all duration-500"
+                                       style="width: <%= other_percentage %>%">
+                                    <span class="text-white text-xs font-medium"><%= other_percentage %>%</span>
+                                  </div>
+                                </div>
+                              </div>
+
+                              <!-- Détail des réponses "autre" pour choix multiple -->
+                              <%
+                                # Pour les choix multiples, récupérer les textes des réponses "autre"
+                                # CORRECTION: Simplifier la requête pour éviter les erreurs PostgreSQL
+                                other_responses = []
+
+                                @user_survey.survey_responses.completed
+                            .joins(:question_responses)
+                            .where(question_responses: { question: question })
+                            .includes(:question_responses)
+                            .each do |sr|
+                              qr = sr.question_responses.find { |response| response.question_id == question.id }
+                              next unless qr&.answer_data.is_a?(Array)
+
+                              qr.answer_data.each do |item|
+                                if item.is_a?(Hash) && item['type'] == 'other' && item['text'].present?
+                                  other_responses << item['text']
+                                end
+                              end
+                            end
+
+                            other_responses = other_responses.compact.reject(&:blank?)
+                              %>
+
+                              <% if other_responses.any? %>
+                                <div class="ml-4 mt-3 p-3 bg-orange-50 rounded-lg border border-orange-200">
+                                  <h5 class="text-sm font-medium text-orange-800 mb-2">Détail des réponses "Autre" :</h5>
+                                  <div class="space-y-1">
+                                    <% other_responses.each do |response_text| %>
+                                      <div class="text-xs text-orange-700 bg-orange-100 px-2 py-1 rounded inline-block mr-1 mb-1">
+                                        "<%= truncate(response_text, length: 50) %>"
+                                      </div>
+                                    <% end %>
+                                  </div>
+                                </div>
+                              <% end %>
+                            <% end %>
                           </div>
                         <% else %>
                           <p class="text-gray-500 italic">Aucune réponse</p>
@@ -370,7 +491,13 @@
                                   data-chart-type="bar"
                                   data-question-id="<%= question.id %>"
                                   data-chart-data="<%= {
-                                    labels: stats.map { |answer, _| question.question_options.find { |o| o.value == answer }&.text || answer },
+                                    labels: stats.map { |answer, _|
+                                      if answer == 'other'
+                                        question.options&.dig('other_text_label') || 'Autre'
+                                      else
+                                        question.question_options.find { |o| o.value == answer }&.text || answer
+                                      end
+                                    },
                                     values: stats.values,
                                     type: 'multiple_choice',
                                     label: 'Nombre de sélections'


### PR DESCRIPTION
Add comprehensive support for custom Other options in survey questions:

• **Question Creation**:
  - Toggle to enable Other option with customizable label
  - JavaScript controller for dynamic form updates
  - Preview functionality showing Other option behavior

• **Survey Response**:
  - Stimulus controller for show/hide other text input
  - Backend processing of structured other responses
  - Data validation for required other text fields

• **Results & Analytics**:
  - Separate counting and display of Other responses
  - Detailed breakdown showing all custom text entries
  - Visual distinction with orange/red color scheme
  - Chart integration with custom labels

• **Data Export**:
  - Dual-column CSV export (option + custom text)
  - Proper handling of Other responses in all formats
  - Backward compatibility with existing data

• **Database Structure**:
  - Enhanced QuestionResponse model with structured JSON data
  - Support for mixed normal/other responses in multiple choice
  - Robust data parsing and formatting methods

Improves survey flexibility by allowing respondents to provide custom answers when predefined options are insufficient.

Fixes PostgreSQL JSON comparison issues in statistics queries.