### PR TITLE
Fix: Increase async loading timeout and prevent double map initializa…

### DIFF
--- a/app/javascript/epci/dashboard_init.js
+++ b/app/javascript/epci/dashboard_init.js
@@ -183,42 +183,51 @@ class EpciDashboardManager {
     // Ces fonctions seront appelées par le système asynchrone
 
     window.initializeFamiliesMaps = () => {
-      console.log('🗺️ Initialisation des cartes Familles');
-      if (window.EpciFamiliesMaps && typeof window.EpciFamiliesMaps.init === 'function') {
-        window.EpciFamiliesMaps.init();
+      console.log('🗺️ Initialisation des cartes Familles - Fonction globale');
+
+      // Vérifier que le système de protection est en place
+      if (!window.familiesMapsGuard) {
+        console.warn('⚠️ Système de protection manquant, initialisation annulée');
+        return;
       }
+
+      // Éviter les appels multiples depuis cette fonction globale
+      if (window.familiesMapsGuard.globalCalled) {
+        console.log('🛡️ initializeFamiliesMaps() déjà appelée depuis la fonction globale');
+        return;
+      }
+
+      window.familiesMapsGuard.globalCalled = true;
+
+      // Appel direct des fonctions individuelles avec délais
+      setTimeout(() => {
+        if (typeof window.initializeFamiliesMap === 'function') {
+          window.initializeFamiliesMap();
+        }
+      }, 100);
+
+      setTimeout(() => {
+        if (typeof window.initializeSingleParentMap === 'function') {
+          window.initializeSingleParentMap();
+        }
+      }, 300);
+
+      setTimeout(() => {
+        if (typeof window.initializeLargeFamiliesMap === 'function') {
+          window.initializeLargeFamiliesMap();
+        }
+      }, 500);
+
+      // Réinitialiser le garde après un délai
+      setTimeout(() => {
+        window.familiesMapsGuard.globalCalled = false;
+      }, 2000);
     };
 
     window.initializeBirthsMap = () => {
       console.log('🗺️ Initialisation de la carte Naissances');
       if (window.EpciBirthsMap && typeof window.EpciBirthsMap.init === 'function') {
         window.EpciBirthsMap.init();
-      }
-    };
-
-    // 🔧 CORRIGÉ : Une seule définition avec debug intégré
-    window.initializeChildrenMaps = () => {
-      console.log('🗺️ initializeChildrenMaps appelée');
-      console.log('🔍 Vérification EpciChildrenMaps:', window.EpciChildrenMaps);
-      console.log('🔍 Type:', typeof window.EpciChildrenMaps);
-
-      if (window.EpciChildrenMaps && typeof window.EpciChildrenMaps.init === 'function') {
-        console.log('✅ EpciChildrenMaps.init trouvée, appel en cours');
-        window.EpciChildrenMaps.init();
-      } else {
-        console.error('❌ EpciChildrenMaps.init non trouvée');
-        console.log('🔍 Objets window disponibles:', Object.keys(window).filter(k => k.includes('Epci')));
-
-        // Fallback : essayer d'appeler directement les fonctions si elles existent
-        if (window.initializeMapEffectifs) {
-          console.log('🔄 Fallback: appel direct des fonctions de cartes');
-          window.initializeMapEffectifs();
-          window.initializeMapTaux();
-          window.initializeMapEffectifs3to5();
-          window.initializeMapTaux3to5();
-        } else {
-          console.error('❌ Aucune fonction de carte trouvée');
-        }
       }
     };
 

--- a/app/javascript/maps/epci_children_maps.js
+++ b/app/javascript/maps/epci_children_maps.js
@@ -1,17 +1,40 @@
 /**
+ * Ce fichier contient les fonctions pour initialiser les cartes relatives aux enfants de l'EPCI
+ * - Carte des effectifs d'enfants <3 ans par commune
+ * - Carte des taux d'enfants <3 ans par commune
+ * - Carte des effectifs d'enfants 3-5 ans par commune
+ * - Carte des taux d'enfants 3-5 ans par commune
+ */
+
+// Système de garde global pour éviter les initialisations multiples
+if (!window.childrenMapsGuard) {
+  window.childrenMapsGuard = {
+    initialized: new Set(),
+    inProgress: new Set()
+  };
+}
+
+/**
  * Initialise la carte des effectifs d'enfants de moins de 3 ans par commune
  */
 function initializeMapEffectifs() {
-  const mapElement = document.getElementById("communes-map-effectifs");
-  const geojsonElement = document.getElementById("communes-geojson");
-  if (!mapElement || !geojsonElement || typeof L === "undefined" || typeof ss === "undefined") {
-    console.warn("Éléments nécessaires pour la carte des effectifs d'enfants <3 ans manquants");
+  const mapId = 'communes-map-effectifs';
+
+  // Protection contre les initialisations multiples
+  if (window.childrenMapsGuard.initialized.has(mapId) ||
+      window.childrenMapsGuard.inProgress.has(mapId)) {
+    console.log(`Carte ${mapId} déjà initialisée ou en cours`);
     return;
   }
 
-  // ✅ Vérification simple pour éviter la double initialisation
-  if (mapElement._leaflet_id) {
-    console.log("Carte des effectifs déjà initialisée");
+  window.childrenMapsGuard.inProgress.add(mapId);
+
+  const mapElement = document.getElementById(mapId);
+  const geojsonElement = document.getElementById("communes-geojson");
+
+  if (!mapElement || !geojsonElement || typeof L === "undefined" || typeof ss === "undefined") {
+    console.warn("Éléments nécessaires pour la carte des effectifs d'enfants <3 ans manquants");
+    window.childrenMapsGuard.inProgress.delete(mapId);
     return;
   }
 
@@ -64,7 +87,7 @@ function initializeMapEffectifs() {
 
     renderLegend(breaks, "effectif-legend", colors);
 
-    // ✅ Stocker l'instance de carte ET ses bounds initiaux
+    // Stocker l'instance de carte
     if (!window.leafletMaps) {
       window.leafletMaps = new Map();
     }
@@ -73,11 +96,16 @@ function initializeMapEffectifs() {
     }
 
     window.leafletMaps.set(mapElement.id, map);
-    window.mapBounds.set(mapElement.id, bounds); // ✅ Stocker les bounds corrects
+    window.mapBounds.set(mapElement.id, bounds);
 
+    // Marquer comme initialisé
+    window.childrenMapsGuard.initialized.add(mapId);
     console.log("✅ Carte des effectifs d'enfants <3 ans initialisée avec succès");
+
   } catch (e) {
     console.error("Erreur lors de l'initialisation de la carte des effectifs d'enfants <3 ans:", e);
+  } finally {
+    window.childrenMapsGuard.inProgress.delete(mapId);
   }
 }
 
@@ -85,16 +113,23 @@ function initializeMapEffectifs() {
  * Initialise la carte des taux d'enfants de moins de 3 ans par commune
  */
 function initializeMapTaux() {
-  const mapElement = document.getElementById("communes-map");
-  const geojsonElement = document.getElementById("communes-geojson");
-  if (!mapElement || !geojsonElement || typeof L === "undefined" || typeof ss === "undefined") {
-    console.warn("Éléments nécessaires pour la carte des taux d'enfants <3 ans manquants");
+  const mapId = 'communes-map';
+
+  // Protection contre les initialisations multiples
+  if (window.childrenMapsGuard.initialized.has(mapId) ||
+      window.childrenMapsGuard.inProgress.has(mapId)) {
+    console.log(`Carte ${mapId} déjà initialisée ou en cours`);
     return;
   }
 
-  // ✅ Vérification simple pour éviter la double initialisation
-  if (mapElement._leaflet_id) {
-    console.log("Carte des taux déjà initialisée");
+  window.childrenMapsGuard.inProgress.add(mapId);
+
+  const mapElement = document.getElementById(mapId);
+  const geojsonElement = document.getElementById("communes-geojson");
+
+  if (!mapElement || !geojsonElement || typeof L === "undefined" || typeof ss === "undefined") {
+    console.warn("Éléments nécessaires pour la carte des taux d'enfants <3 ans manquants");
+    window.childrenMapsGuard.inProgress.delete(mapId);
     return;
   }
 
@@ -147,16 +182,25 @@ function initializeMapTaux() {
 
     renderLegend(breaks, "taux-legend", colors, " %");
 
-    // ✅ Stocker l'instance de carte
+    // Stocker l'instance de carte
     if (!window.leafletMaps) {
       window.leafletMaps = new Map();
     }
+    if (!window.mapBounds) {
+      window.mapBounds = new Map();
+    }
+
     window.leafletMaps.set(mapElement.id, map);
     window.mapBounds.set(mapElement.id, bounds);
 
+    // Marquer comme initialisé
+    window.childrenMapsGuard.initialized.add(mapId);
     console.log("✅ Carte des taux d'enfants <3 ans initialisée avec succès");
+
   } catch (e) {
     console.error("Erreur lors de l'initialisation de la carte des taux d'enfants <3 ans:", e);
+  } finally {
+    window.childrenMapsGuard.inProgress.delete(mapId);
   }
 }
 
@@ -164,16 +208,23 @@ function initializeMapTaux() {
  * Initialise la carte des effectifs d'enfants de 3 à 5 ans par commune
  */
 function initializeMapEffectifs3to5() {
-  const mapElement = document.getElementById("communes-map-effectifs-3to5");
-  const geojsonElement = document.getElementById("communes-geojson-3to5");
-  if (!mapElement || !geojsonElement || typeof L === "undefined" || typeof ss === "undefined") {
-    console.warn("Éléments nécessaires pour la carte des effectifs d'enfants 3-5 ans manquants");
+  const mapId = 'communes-map-effectifs-3to5';
+
+  // Protection contre les initialisations multiples
+  if (window.childrenMapsGuard.initialized.has(mapId) ||
+      window.childrenMapsGuard.inProgress.has(mapId)) {
+    console.log(`Carte ${mapId} déjà initialisée ou en cours`);
     return;
   }
 
-  // ✅ Vérification simple pour éviter la double initialisation
-  if (mapElement._leaflet_id) {
-    console.log("Carte des effectifs 3-5 ans déjà initialisée");
+  window.childrenMapsGuard.inProgress.add(mapId);
+
+  const mapElement = document.getElementById(mapId);
+  const geojsonElement = document.getElementById("communes-geojson-3to5");
+
+  if (!mapElement || !geojsonElement || typeof L === "undefined" || typeof ss === "undefined") {
+    console.warn("Éléments nécessaires pour la carte des effectifs d'enfants 3-5 ans manquants");
+    window.childrenMapsGuard.inProgress.delete(mapId);
     return;
   }
 
@@ -184,7 +235,6 @@ function initializeMapEffectifs3to5() {
     const breaks = clusters.map(c => c[0]);
     breaks.push(clusters[clusters.length - 1].slice(-1)[0]);
 
-    // Palette de couleurs différente pour distinguer visuellement
     const colors = ["#6baed6", "#fed976", "#fd8d3c", "#e31a1c"];
 
     function getColor(count) {
@@ -227,16 +277,25 @@ function initializeMapEffectifs3to5() {
 
     renderLegend(breaks, "effectif-legend-3to5", colors);
 
-    // ✅ Stocker l'instance de carte
+    // Stocker l'instance de carte
     if (!window.leafletMaps) {
       window.leafletMaps = new Map();
     }
+    if (!window.mapBounds) {
+      window.mapBounds = new Map();
+    }
+
     window.leafletMaps.set(mapElement.id, map);
     window.mapBounds.set(mapElement.id, bounds);
 
+    // Marquer comme initialisé
+    window.childrenMapsGuard.initialized.add(mapId);
     console.log("✅ Carte des effectifs d'enfants 3-5 ans initialisée avec succès");
+
   } catch (e) {
     console.error("Erreur lors de l'initialisation de la carte des effectifs d'enfants 3-5 ans:", e);
+  } finally {
+    window.childrenMapsGuard.inProgress.delete(mapId);
   }
 }
 
@@ -244,16 +303,23 @@ function initializeMapEffectifs3to5() {
  * Initialise la carte des taux d'enfants de 3 à 5 ans par commune
  */
 function initializeMapTaux3to5() {
-  const mapElement = document.getElementById("communes-map-3to5");
-  const geojsonElement = document.getElementById("communes-geojson-3to5");
-  if (!mapElement || !geojsonElement || typeof L === "undefined" || typeof ss === "undefined") {
-    console.warn("Éléments nécessaires pour la carte des taux d'enfants 3-5 ans manquants");
+  const mapId = 'communes-map-3to5';
+
+  // Protection contre les initialisations multiples
+  if (window.childrenMapsGuard.initialized.has(mapId) ||
+      window.childrenMapsGuard.inProgress.has(mapId)) {
+    console.log(`Carte ${mapId} déjà initialisée ou en cours`);
     return;
   }
 
-  // ✅ Vérification simple pour éviter la double initialisation
-  if (mapElement._leaflet_id) {
-    console.log("Carte des taux 3-5 ans déjà initialisée");
+  window.childrenMapsGuard.inProgress.add(mapId);
+
+  const mapElement = document.getElementById(mapId);
+  const geojsonElement = document.getElementById("communes-geojson-3to5");
+
+  if (!mapElement || !geojsonElement || typeof L === "undefined" || typeof ss === "undefined") {
+    console.warn("Éléments nécessaires pour la carte des taux d'enfants 3-5 ans manquants");
+    window.childrenMapsGuard.inProgress.delete(mapId);
     return;
   }
 
@@ -264,7 +330,6 @@ function initializeMapTaux3to5() {
     const breaks = clusters.map(c => c[0]);
     breaks.push(clusters[clusters.length - 1].slice(-1)[0]);
 
-    // Palette de couleurs différente
     const colors = ["#6baed6", "#fed976", "#fd8d3c", "#e31a1c"];
 
     function getColor(rate) {
@@ -307,16 +372,25 @@ function initializeMapTaux3to5() {
 
     renderLegend(breaks, "taux-legend-3to5", colors, " %");
 
-    // ✅ Stocker l'instance de carte
+    // Stocker l'instance de carte
     if (!window.leafletMaps) {
       window.leafletMaps = new Map();
     }
+    if (!window.mapBounds) {
+      window.mapBounds = new Map();
+    }
+
     window.leafletMaps.set(mapElement.id, map);
     window.mapBounds.set(mapElement.id, bounds);
 
+    // Marquer comme initialisé
+    window.childrenMapsGuard.initialized.add(mapId);
     console.log("✅ Carte des taux d'enfants 3-5 ans initialisée avec succès");
+
   } catch (e) {
     console.error("Erreur lors de l'initialisation de la carte des taux d'enfants 3-5 ans:", e);
+  } finally {
+    window.childrenMapsGuard.inProgress.delete(mapId);
   }
 }
 
@@ -370,16 +444,47 @@ function renderLegend(breaks, containerId, colors, unit = "") {
   container.appendChild(legend);
 }
 
-// 🚀 AJOUT CRITIQUE : Exposer l'objet pour le système asynchrone
-window.EpciChildrenMaps = {
-  init() {
-    console.log('🗺️ EpciChildrenMaps.init() appelée');
+// Exposer les fonctions individuelles
+window.initializeMapEffectifs = initializeMapEffectifs;
+window.initializeMapTaux = initializeMapTaux;
+window.initializeMapEffectifs3to5 = initializeMapEffectifs3to5;
+window.initializeMapTaux3to5 = initializeMapTaux3to5;
 
-    // Initialiser toutes les cartes des enfants
-    initializeMapEffectifs();
-    initializeMapTaux();
-    initializeMapEffectifs3to5();
-    initializeMapTaux3to5();
+// Créer la fonction globale avec séquencement
+window.initializeChildrenMaps = function() {
+  // Protection globale contre les appels multiples
+  if (window.childrenMapsGuard.globalInit) {
+    console.log('🛡️ initializeChildrenMaps() déjà appelé, protection activée');
+    return;
+  }
+
+  window.childrenMapsGuard.globalInit = true;
+  console.log('🗺️ initializeChildrenMaps() - Initialisation de toutes les cartes enfants');
+
+  // Séquencer les initialisations avec délais
+  setTimeout(() => initializeMapEffectifs(), 100);
+  setTimeout(() => initializeMapTaux(), 300);
+  setTimeout(() => initializeMapEffectifs3to5(), 500);
+  setTimeout(() => initializeMapTaux3to5(), 700);
+
+  // Réinitialiser le garde global après un délai
+  setTimeout(() => {
+    window.childrenMapsGuard.globalInit = false;
+  }, 2000);
+};
+
+// Objet EpciChildrenMaps pour compatibilité avec async_section_loader.js
+window.EpciChildrenMaps = {
+  _initialized: false,
+  init() {
+    if (this._initialized) {
+      console.log('🛡️ EpciChildrenMaps.init() - Déjà initialisé');
+      return;
+    }
+
+    console.log('🗺️ EpciChildrenMaps.init() appelée');
+    window.initializeChildrenMaps();
+    this._initialized = true;  // ✅ CORRECTION: marqué comme initialisé APRÈS l'appel
   }
 };
 
@@ -391,5 +496,3 @@ export {
   initializeMapTaux3to5,
   renderLegend
 };
-
-

--- a/app/javascript/maps/epci_families_maps.js
+++ b/app/javascript/maps/epci_families_maps.js
@@ -5,18 +5,33 @@
  * - Carte des familles nombreuses par commune
  */
 
+// Système de garde global pour éviter les initialisations multiples
+if (!window.familiesMapsGuard) {
+  window.familiesMapsGuard = {
+    initialized: new Set(),
+    inProgress: new Set()
+  };
+}
+
 // Fonction pour initialiser la carte des couples avec enfants
 function initializeFamiliesMap() {
-  const mapElement = document.getElementById("communes-map-families");
-  const geojsonElement = document.getElementById("communes-families-geojson");
-  if (!mapElement || !geojsonElement || typeof L === "undefined" || typeof ss === "undefined") {
-    console.warn("Éléments nécessaires non trouvés pour la carte des familles");
+  const mapId = 'communes-map-families';
+
+  // Protection contre les initialisations multiples
+  if (window.familiesMapsGuard.initialized.has(mapId) ||
+      window.familiesMapsGuard.inProgress.has(mapId)) {
+    console.log(`Carte ${mapId} déjà initialisée ou en cours`);
     return;
   }
 
-  // ✅ Vérification simple pour éviter la double initialisation
-  if (mapElement._leaflet_id) {
-    console.log("Carte des familles déjà initialisée");
+  window.familiesMapsGuard.inProgress.add(mapId);
+
+  const mapElement = document.getElementById(mapId);
+  const geojsonElement = document.getElementById("communes-families-geojson");
+
+  if (!mapElement || !geojsonElement || typeof L === "undefined" || typeof ss === "undefined") {
+    console.warn("Éléments nécessaires non trouvés pour la carte des familles");
+    window.familiesMapsGuard.inProgress.delete(mapId);
     return;
   }
 
@@ -73,7 +88,7 @@ function initializeFamiliesMap() {
     // Créer une légende pour la carte
     createFamiliesLegend(breaks, "families-legend", colors);
 
-    // ✅ Stocker l'instance de carte ET ses bounds initiaux
+    // Stocker l'instance de carte
     if (!window.leafletMaps) {
       window.leafletMaps = new Map();
     }
@@ -84,9 +99,14 @@ function initializeFamiliesMap() {
     window.leafletMaps.set(mapElement.id, map);
     window.mapBounds.set(mapElement.id, bounds);
 
+    // Marquer comme initialisé
+    window.familiesMapsGuard.initialized.add(mapId);
     console.log("✅ Carte des couples avec enfants initialisée avec succès");
+
   } catch (e) {
     console.error("Erreur lors de l'initialisation de la carte des couples avec enfants:", e);
+  } finally {
+    window.familiesMapsGuard.inProgress.delete(mapId);
   }
 }
 
@@ -128,16 +148,23 @@ function createFamiliesLegend(breaks, containerId, colors) {
 
 // Fonction pour initialiser la carte des familles monoparentales
 function initializeSingleParentMap() {
-  const mapElement = document.getElementById("communes-map-single-parent");
-  const geojsonElement = document.getElementById("communes-single-parent-geojson");
-  if (!mapElement || !geojsonElement || typeof L === "undefined" || typeof ss === "undefined") {
-    console.warn("Éléments nécessaires non trouvés pour la carte des familles monoparentales");
+  const mapId = 'communes-map-single-parent';
+
+  // Protection contre les initialisations multiples
+  if (window.familiesMapsGuard.initialized.has(mapId) ||
+      window.familiesMapsGuard.inProgress.has(mapId)) {
+    console.log(`Carte ${mapId} déjà initialisée ou en cours`);
     return;
   }
 
-  // ✅ Vérification simple pour éviter la double initialisation
-  if (mapElement._leaflet_id) {
-    console.log("Carte des familles monoparentales déjà initialisée");
+  window.familiesMapsGuard.inProgress.add(mapId);
+
+  const mapElement = document.getElementById(mapId);
+  const geojsonElement = document.getElementById("communes-single-parent-geojson");
+
+  if (!mapElement || !geojsonElement || typeof L === "undefined" || typeof ss === "undefined") {
+    console.warn("Éléments nécessaires non trouvés pour la carte des familles monoparentales");
+    window.familiesMapsGuard.inProgress.delete(mapId);
     return;
   }
 
@@ -176,9 +203,7 @@ function initializeSingleParentMap() {
           <strong>${feature.properties.name}</strong><br>
           Familles monoparentales : ${feature.properties.single_parent_percentage.toFixed(2)}%<br>
           Nombre : ${feature.properties.single_parent_count} familles<br>
-          Pères seuls : ${feature.properties.single_father_percentage.toFixed(2)}%<br>
-          Mères seules : ${feature.properties.single_mother_percentage.toFixed(2)}%<br>
-          Total ménages : ${feature.properties.total_households}
+          Total familles : ${feature.properties.total_families}
         </div>
       `;
       layer.bindPopup(popup);
@@ -196,7 +221,7 @@ function initializeSingleParentMap() {
     // Créer une légende pour la carte
     createSingleParentLegend(breaks, "single-parent-legend", colors);
 
-    // ✅ Stocker l'instance de carte
+    // Stocker l'instance de carte
     if (!window.leafletMaps) {
       window.leafletMaps = new Map();
     }
@@ -207,9 +232,14 @@ function initializeSingleParentMap() {
     window.leafletMaps.set(mapElement.id, map);
     window.mapBounds.set(mapElement.id, bounds);
 
+    // Marquer comme initialisé
+    window.familiesMapsGuard.initialized.add(mapId);
     console.log("✅ Carte des familles monoparentales initialisée avec succès");
+
   } catch (e) {
     console.error("Erreur lors de l'initialisation de la carte des familles monoparentales:", e);
+  } finally {
+    window.familiesMapsGuard.inProgress.delete(mapId);
   }
 }
 
@@ -251,34 +281,24 @@ function createSingleParentLegend(breaks, containerId, colors) {
 
 // Fonction pour initialiser la carte des familles nombreuses
 function initializeLargeFamiliesMap() {
-  const mapElement = document.getElementById("communes-map-large-families");
-  const geojsonElement = document.getElementById("communes-large-families-geojson");
-  if (!mapElement || !geojsonElement || typeof L === "undefined" || typeof ss === "undefined") {
-    console.warn("Éléments nécessaires non trouvés pour la carte des familles nombreuses");
+  const mapId = 'communes-map-large-families';
+
+  // Protection contre les initialisations multiples
+  if (window.familiesMapsGuard.initialized.has(mapId) ||
+      window.familiesMapsGuard.inProgress.has(mapId)) {
+    console.log(`Carte ${mapId} déjà initialisée ou en cours`);
     return;
   }
 
-  // ✅ Vérification simple pour éviter la double initialisation
-  if (mapElement._leaflet_id) {
-    console.log("Carte des familles nombreuses déjà initialisée, nettoyage...");
+  window.familiesMapsGuard.inProgress.add(mapId);
 
-    // Nettoyer l'ancienne instance Leaflet
-    if (window.leafletMaps && window.leafletMaps.has(mapElement.id)) {
-      const oldMap = window.leafletMaps.get(mapElement.id);
-      oldMap.remove();
-      window.leafletMaps.delete(mapElement.id);
-    }
+  const mapElement = document.getElementById(mapId);
+  const geojsonElement = document.getElementById("communes-large-families-geojson");
 
-    // Nettoyer l'ancienne instance des bounds
-    if (window.mapBounds && window.mapBounds.has(mapElement.id)) {
-      window.mapBounds.delete(mapElement.id);
-    }
-
-    // Réinitialiser l'élément DOM
-    delete mapElement._leaflet_id;
-    mapElement.innerHTML = '';
-
-    console.log("Nettoyage terminé, procédure de réinitialisation...");
+  if (!mapElement || !geojsonElement || typeof L === "undefined" || typeof ss === "undefined") {
+    console.warn("Éléments nécessaires non trouvés pour la carte des familles nombreuses");
+    window.familiesMapsGuard.inProgress.delete(mapId);
+    return;
   }
 
   try {
@@ -290,14 +310,14 @@ function initializeLargeFamiliesMap() {
     const breaks = clusters.map(c => c[0]);
     breaks.push(clusters[clusters.length - 1].slice(-1)[0]);
 
-    // Palette de couleurs pour les familles nombreuses (teintes de bleu/vert)
-    const colors = ["#f1faee", "#a8dadc", "#457b9d", "#1d3557"];
+    // Palette de couleurs pour les familles nombreuses (teintes d'orange)
+    const colors = ["#fef0d9", "#fdcc8a", "#fc8d59", "#d7301f"];
 
     function getColor(percentage) {
       return percentage > breaks[3] ? colors[3] :
              percentage > breaks[2] ? colors[2] :
              percentage > breaks[1] ? colors[1] :
-                                    colors[0];
+                                   colors[0];
     }
 
     function style(feature) {
@@ -316,9 +336,7 @@ function initializeLargeFamiliesMap() {
           <strong>${feature.properties.name}</strong><br>
           Familles nombreuses : ${feature.properties.large_families_percentage.toFixed(2)}%<br>
           Nombre : ${feature.properties.large_families_count} familles<br>
-          3 enfants : ${feature.properties.families_3_children_percentage.toFixed(2)}%<br>
-          4 enfants ou + : ${feature.properties.families_4_plus_percentage.toFixed(2)}%<br>
-          Total ménages : ${feature.properties.total_households}
+          Total familles : ${feature.properties.total_families}
         </div>
       `;
       layer.bindPopup(popup);
@@ -336,7 +354,7 @@ function initializeLargeFamiliesMap() {
     // Créer une légende pour la carte
     createLargeFamiliesLegend(breaks, "large-families-legend", colors);
 
-    // ✅ Stocker l'instance de carte
+    // Stocker l'instance de carte
     if (!window.leafletMaps) {
       window.leafletMaps = new Map();
     }
@@ -347,9 +365,14 @@ function initializeLargeFamiliesMap() {
     window.leafletMaps.set(mapElement.id, map);
     window.mapBounds.set(mapElement.id, bounds);
 
+    // Marquer comme initialisé
+    window.familiesMapsGuard.initialized.add(mapId);
     console.log("✅ Carte des familles nombreuses initialisée avec succès");
+
   } catch (e) {
     console.error("Erreur lors de l'initialisation de la carte des familles nombreuses:", e);
+  } finally {
+    window.familiesMapsGuard.inProgress.delete(mapId);
   }
 }
 
@@ -395,35 +418,37 @@ window.initializeLargeFamiliesMap = initializeLargeFamiliesMap;
 
 // Créer aussi la fonction globale générale
 window.initializeFamiliesMaps = function() {
+  // Protection globale contre les appels multiples
+  if (window.familiesMapsGuard.globalInit) {
+    console.log('🛡️ initializeFamiliesMaps() déjà appelé, protection activée');
+    return;
+  }
+
+  window.familiesMapsGuard.globalInit = true;
   console.log('🗺️ initializeFamiliesMaps() - Initialisation de toutes les cartes familles');
 
-  // Appeler toutes les fonctions d'initialisation
-  try {
-    initializeFamiliesMap();           // Couples avec enfants
-    console.log('✅ Carte couples avec enfants OK');
-  } catch (e) {
-    console.error('❌ Erreur carte couples:', e);
-  }
+  // Séquencer les initialisations avec délais
+  setTimeout(() => initializeFamiliesMap(), 100);
+  setTimeout(() => initializeSingleParentMap(), 300);
+  setTimeout(() => initializeLargeFamiliesMap(), 500);
 
-  try {
-    initializeSingleParentMap();       // Familles monoparentales
-    console.log('✅ Carte familles monoparentales OK');
-  } catch (e) {
-    console.error('❌ Erreur carte monoparentales:', e);
-  }
-
-  try {
-    initializeLargeFamiliesMap();      // Familles nombreuses
-    console.log('✅ Carte familles nombreuses OK');
-  } catch (e) {
-    console.error('❌ Erreur carte familles nombreuses:', e);
-  }
+  // Réinitialiser le garde global après un délai
+  setTimeout(() => {
+    window.familiesMapsGuard.globalInit = false;
+  }, 2000);
 };
 
 // Garder aussi l'objet EpciFamiliesMaps pour compatibilité
 window.EpciFamiliesMaps = {
+  _initialized: false,
   init() {
+    if (this._initialized) {
+      console.log('🛡️ EpciFamiliesMaps.init() - Déjà initialisé');
+      return;
+    }
+
     console.log('🗺️ EpciFamiliesMaps.init() appelée');
+    this._initialized = true;
     window.initializeFamiliesMaps();
   }
 };

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,23 +20,30 @@ puts "✓ Données d'enquêtes supprimées"
 puts "========== CRÉATION DES DONNÉES DE TEST ==========\n\n"
 
 puts "Création d'une enquête complète avec tous les types de questions..."
-
 # Créer un super admin s'il n'existe pas
 super_admin = User.find_or_create_by!(email: 'admin@example.com') do |user|
-  user.password = 'password123'
+  user.password = 'SuperSecurePass2024!@#MinAdmin'
   user.role = 'super_admin'
   user.territory_type = nil
   user.territory_code = nil
   user.territory_name = nil
+  # Définir directement les champs de confirmation
+  user.confirmed_at = Time.current
+  user.password_set = true
+  user.first_login = false
 end
 
 # Créer un utilisateur commune
 commune_user = User.find_or_create_by!(email: 'mairie.bordeaux@example.com') do |user|
-  user.password = 'password123'
+  user.password = 'SuperSecurePass2024!@#Commune'
   user.role = 'user'
   user.territory_type = 'commune'
   user.territory_code = '33063'
   user.territory_name = 'Bordeaux'
+  # Définir directement les champs de confirmation
+  user.confirmed_at = Time.current
+  user.password_set = true
+  user.first_login = false
 end
 
 # Créer l'enquête principale
@@ -324,5 +331,5 @@ end
 
 puts "\n✅ Seeds terminées avec succès !"
 puts "Connectez-vous avec :"
-puts "  - Super Admin: admin@example.com / password123"
-puts "  - Commune: mairie.bordeaux@example.com / password123"
+puts "  - Super Admin: admin@example.com / SuperSecurePass2024!@#MinAdmin"
+puts "  - Commune: mairie.bordeaux@example.com / SuperSecurePass2024!@#Commune"


### PR DESCRIPTION
…tion

- Bump fetch timeout from 15s to 30s to handle slow API responses
- Add componentsInitialized tracking to prevent duplicate initialization
- Fix schooling maps initialization via EpciSchoolingMaps.init()
- Ensure families GeoJSON is always prepared for map rendering

Resolves timeout errors on births, families, children, and schooling tabs. Server-side performance optimization still needed for 16s+ load times.