### PR TITLE
feat(epci-dashboard): add welcome tab as default landing page

### DIFF
--- a/app/controllers/epci_dashboard_controller.rb
+++ b/app/controllers/epci_dashboard_controller.rb
@@ -321,12 +321,21 @@ class EpciDashboardController < ApplicationController
       region: @main_region_code
     }
 
-    # ✅ AJOUT CRITIQUE : Charger les données des communes pour la recherche
+    # ✅ Charger les données des communes pour la recherche
     cache_key = "epci:#{@epci_code}:essential:v1"
     @epci_communes_data = Rails.cache.fetch(cache_key, expires_in: 6.hours) do
       Rails.logger.info "📄 Chargement données essentielles communes pour #{@epci_code}"
       EpciCacheService.epci_essential_data(@epci_code)
     end
+
+    # ✅ Charger aussi les données de population pour l'onglet Accueil
+    population_cache_key = "epci:#{@epci_code}:population:v1"
+    @population_data = Rails.cache.fetch(population_cache_key, expires_in: 6.hours) do
+      Rails.logger.info "📊 Chargement données population pour accueil #{@epci_code}"
+      EpciCacheService.epci_children_data(@epci_code)
+    end
+
+    @epci_population_data = @population_data[:population_data] || {}
 
     Rails.logger.info "✅ Chargement minimal terminé pour #{@epci_code} avec #{@epci_communes_data&.dig('communes')&.count || 0} communes"
   end

--- a/app/javascript/controllers/tabs_controller.js
+++ b/app/javascript/controllers/tabs_controller.js
@@ -7,13 +7,15 @@ export default class extends Controller {
   static values = { defaultTab: String }
 
   connect() {
-    // Restaurer l'onglet sauvegardé ou utiliser l'onglet par défaut
-    const storedTab = this.getStoredActiveTab()
-    const defaultTabId = storedTab || this.defaultTabValue || this.tabTargets[0]?.dataset.tabId
+    // ✅ Toujours rediriger vers l'onglet Accueil
+    const defaultTabId = 'accueil';
 
     if (defaultTabId) {
       this.showTab(defaultTabId)
     }
+
+    // Nettoyer l'ancien localStorage
+    localStorage.removeItem('epci-dashboard-active-tab');
   }
 
   switch(event) {
@@ -24,6 +26,17 @@ export default class extends Controller {
     this.triggerAsyncLoad(tabId)
 
     this.showTab(tabId)
+
+    // ✅ Scroll vers la barre de navigation des onglets
+    setTimeout(() => {
+      const tabsNavigation = document.getElementById('tabs-navigation');
+      if (tabsNavigation) {
+        tabsNavigation.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start'
+        });
+      }
+    }, 50);
   }
 
   // NOUVELLE MÉTHODE: Déclencher le chargement asynchrone sans attendre

--- a/app/views/epci_dashboard/_accueil.html.erb
+++ b/app/views/epci_dashboard/_accueil.html.erb
@@ -1,0 +1,255 @@
+<!-- app/views/epci_dashboard/_accueil.html.erb -->
+<div class="bg-white/70 backdrop-blur-md rounded-2xl shadow-xl border border-white/20 p-8">
+
+  <!-- En-tête d'accueil -->
+  <div class="text-center mb-8">
+    <div class="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-r from-indigo-500 to-purple-600 rounded-full mb-4">
+      <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"></path>
+      </svg>
+    </div>
+    <h2 class="text-3xl font-bold bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent mb-4">
+      Bienvenue sur le Dashboard EPCI
+    </h2>
+    <p class="text-gray-600 text-lg">
+      <%= @epci_name %>
+    </p>
+  </div>
+
+  <!-- Présentation générale -->
+  <div class="max-w-3xl mx-auto mb-8">
+    <div class="bg-gradient-to-r from-blue-50 to-indigo-50 rounded-xl p-6 border border-blue-100">
+      <p class="text-gray-700 leading-relaxed text-center">
+        Ce tableau de bord vous permet d'explorer les données territoriales de votre intercommunalité.
+        Découvrez les statistiques démographiques, économiques et sociales des
+        <strong class="text-indigo-600"><%= @epci_communes_data&.dig("communes")&.count || 0 %> communes</strong>
+        qui composent votre territoire.
+      </p>
+    </div>
+  </div>
+
+  <!-- Indicateurs clés en un coup d'œil -->
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+    <!-- Population totale -->
+    <div class="bg-gradient-to-br from-blue-50 to-indigo-50 rounded-xl p-6 border border-blue-100 hover:shadow-lg transition-shadow duration-300">
+      <div class="flex items-center justify-between mb-3">
+        <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">Population totale</h3>
+        <div class="p-2 bg-blue-100 rounded-lg">
+          <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
+          </svg>
+        </div>
+      </div>
+      <p class="text-4xl font-bold text-gray-900 mb-1">
+        <%= number_with_delimiter(@epci_population_data["total_population"]&.round || 0, delimiter: " ") %>
+      </p>
+      <p class="text-sm text-gray-500">habitants recensés</p>
+    </div>
+
+    <!-- Nombre de communes -->
+    <div class="bg-gradient-to-br from-emerald-50 to-green-50 rounded-xl p-6 border border-emerald-100 hover:shadow-lg transition-shadow duration-300">
+      <div class="flex items-center justify-between mb-3">
+        <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">Communes</h3>
+        <div class="p-2 bg-emerald-100 rounded-lg">
+          <svg class="w-6 h-6 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path>
+          </svg>
+        </div>
+      </div>
+      <p class="text-4xl font-bold text-gray-900 mb-1">
+        <%= @epci_communes_data&.dig("communes")&.count || 0 %>
+      </p>
+      <p class="text-sm text-gray-500">communes membres</p>
+    </div>
+
+    <!-- Code EPCI -->
+    <div class="bg-gradient-to-br from-purple-50 to-pink-50 rounded-xl p-6 border border-purple-100 hover:shadow-lg transition-shadow duration-300">
+      <div class="flex items-center justify-between mb-3">
+        <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">Code EPCI</h3>
+        <div class="p-2 bg-purple-100 rounded-lg">
+          <svg class="w-6 h-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14"></path>
+          </svg>
+        </div>
+      </div>
+      <p class="text-4xl font-bold text-gray-900 mb-1">
+        <%= @epci_code %>
+      </p>
+      <p class="text-sm text-gray-500">identifiant territorial</p>
+    </div>
+  </div>
+
+  <!-- Navigation rapide vers les sections -->
+  <div class="bg-gradient-to-br from-indigo-50 via-purple-50 to-pink-50 rounded-2xl p-8 border border-indigo-100">
+    <div class="text-center mb-6">
+      <h3 class="text-xl font-bold text-gray-900 mb-2">Explorer les données du territoire</h3>
+      <p class="text-gray-600">Cliquez sur une section pour accéder aux données détaillées</p>
+    </div>
+
+    <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
+      <!-- Population -->
+      <button onclick="document.querySelector('[data-tab-id=population]').click()"
+              class="group flex flex-col items-center space-y-2 px-4 py-4 bg-white rounded-xl hover:shadow-lg transition-all duration-300 border border-gray-200 hover:border-indigo-300 hover:scale-105">
+        <div class="p-3 bg-indigo-100 rounded-lg group-hover:bg-indigo-200 transition-colors">
+          <svg class="w-6 h-6 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
+          </svg>
+        </div>
+        <span class="text-sm font-semibold text-gray-700 group-hover:text-indigo-600 transition-colors">Population</span>
+      </button>
+
+      <!-- Naissances -->
+      <button onclick="document.querySelector('[data-tab-id=births]').click()"
+              class="group flex flex-col items-center space-y-2 px-4 py-4 bg-white rounded-xl hover:shadow-lg transition-all duration-300 border border-gray-200 hover:border-pink-300 hover:scale-105">
+        <div class="p-3 bg-pink-100 rounded-lg group-hover:bg-pink-200 transition-colors">
+          <svg class="w-6 h-6 text-pink-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"></path>
+          </svg>
+        </div>
+        <span class="text-sm font-semibold text-gray-700 group-hover:text-pink-600 transition-colors">Naissances</span>
+      </button>
+
+      <!-- Familles -->
+      <button onclick="document.querySelector('[data-tab-id=families]').click()"
+              class="group flex flex-col items-center space-y-2 px-4 py-4 bg-white rounded-xl hover:shadow-lg transition-all duration-300 border border-gray-200 hover:border-emerald-300 hover:scale-105">
+        <div class="p-3 bg-emerald-100 rounded-lg group-hover:bg-emerald-200 transition-colors">
+          <svg class="w-6 h-6 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <g stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <circle cx="10" cy="7" r="3"/>
+              <path d="M4 21v-2a6 6 0 016-6h0a6 6 0 016 6v2"/>
+              <circle cx="17" cy="10" r="2"/>
+              <path d="M14 21v-1.5a3 3 0 013-3h0a3 3 0 013 3V21"/>
+            </g>
+          </svg>
+        </div>
+        <span class="text-sm font-semibold text-gray-700 group-hover:text-emerald-600 transition-colors">Composition des familles</span>
+      </button>
+
+      <!-- Enfants -->
+      <button onclick="document.querySelector('[data-tab-id=children]').click()"
+              class="group flex flex-col items-center space-y-2 px-4 py-4 bg-white rounded-xl hover:shadow-lg transition-all duration-300 border border-gray-200 hover:border-yellow-300 hover:scale-105">
+        <div class="p-3 bg-yellow-100 rounded-lg group-hover:bg-yellow-200 transition-colors">
+          <svg class="w-5 h-5 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <circle cx="12" cy="12" r="9" stroke-width="2"/>
+            <circle cx="9" cy="10" r="1.5" fill="currentColor"/>
+            <circle cx="15" cy="10" r="1.5" fill="currentColor"/>
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 15s1.5 2 4 2 4-2 4-2"/>
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3c-2 0-3 1-3 1"/>
+          </svg>
+        </div>
+        <span class="text-sm font-semibold text-gray-700 group-hover:text-yellow-600 transition-colors">Enfants de moins de 6 ans</span>
+      </button>
+
+      <!-- Scolarisation -->
+      <button onclick="document.querySelector('[data-tab-id=schooling]').click()"
+              class="group flex flex-col items-center space-y-2 px-4 py-4 bg-white rounded-xl hover:shadow-lg transition-all duration-300 border border-gray-200 hover:border-blue-300 hover:scale-105">
+        <div class="p-3 bg-blue-100 rounded-lg group-hover:bg-blue-200 transition-colors">
+          <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
+          </svg>
+        </div>
+        <span class="text-sm font-semibold text-gray-700 group-hover:text-blue-600 transition-colors">Scolarisation</span>
+      </button>
+
+      <!-- Économie -->
+      <button onclick="document.querySelector('[data-tab-id=economy]').click()"
+              class="group flex flex-col items-center space-y-2 px-4 py-4 bg-white rounded-xl hover:shadow-lg transition-all duration-300 border border-gray-200 hover:border-green-300 hover:scale-105">
+        <div class="p-3 bg-green-100 rounded-lg group-hover:bg-green-200 transition-colors">
+          <svg class="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.121 15.536c-1.171 1.952-3.07 1.952-4.242 0-1.172-1.953-1.172-5.119 0-7.072 1.171-1.952 3.07-1.952 4.242 0M8 10.5h4m-4 3h4m9-1.5a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+          </svg>
+        </div>
+        <span class="text-sm font-semibold text-gray-700 group-hover:text-green-600 transition-colors">Revenus</span>
+      </button>
+
+      <!-- Petite Enfance -->
+      <button onclick="document.querySelector('[data-tab-id=childcare]').click()"
+              class="group flex flex-col items-center space-y-2 px-4 py-4 bg-white rounded-xl hover:shadow-lg transition-all duration-300 border border-gray-200 hover:border-purple-300 hover:scale-105">
+        <div class="p-3 bg-purple-100 rounded-lg group-hover:bg-purple-200 transition-colors">
+          <svg class="w-6 h-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path>
+          </svg>
+        </div>
+        <span class="text-sm font-semibold text-gray-700 group-hover:text-purple-600 transition-colors">Capacité d'accueil</span>
+      </button>
+
+      <!-- Emploi Familles -->
+      <button onclick="document.querySelector('[data-tab-id=family-employment]').click()"
+              class="group flex flex-col items-center space-y-2 px-4 py-4 bg-white rounded-xl hover:shadow-lg transition-all duration-300 border border-gray-200 hover:border-teal-300 hover:scale-105">
+        <div class="p-3 bg-teal-100 rounded-lg group-hover:bg-teal-200 transition-colors">
+          <svg class="w-6 h-6 text-teal-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7H4a2 2 0 00-2 2v10a2 2 0 002 2h16a2 2 0 002-2V9a2 2 0 00-2-2z"></path>
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2"></path>
+          </svg>
+        </div>
+        <span class="text-sm font-semibold text-gray-700 group-hover:text-teal-600 transition-colors text-center">Emploi des familles</span>
+      </button>
+
+      <!-- Emploi Femmes -->
+      <button onclick="document.querySelector('[data-tab-id=women-employment]').click()"
+              class="group flex flex-col items-center space-y-2 px-4 py-4 bg-white rounded-xl hover:shadow-lg transition-all duration-300 border border-gray-200 hover:border-rose-300 hover:scale-105">
+        <div class="p-3 bg-rose-100 rounded-lg group-hover:bg-rose-200 transition-colors">
+          <svg class="w-6 h-6 text-rose-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <g stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+              <circle cx="12" cy="9" r="5"/>
+              <path d="M12 19v-5"/>
+              <path d="M9 17h6"/>
+            </g>
+          </svg>
+        </div>
+        <span class="text-sm font-semibold text-gray-700 group-hover:text-rose-600 transition-colors text-center">Emploi des femmes</span>
+      </button>
+
+      <!-- Violences -->
+      <button onclick="document.querySelector('[data-tab-id=violence]').click()"
+              class="group flex flex-col items-center space-y-2 px-4 py-4 bg-white rounded-xl hover:shadow-lg transition-all duration-300 border border-gray-200 hover:border-red-300 hover:scale-105">
+        <div class="p-3 bg-red-100 rounded-lg group-hover:bg-red-200 transition-colors">
+          <svg class="w-6 h-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
+          </svg>
+        </div>
+        <span class="text-sm font-semibold text-gray-700 group-hover:text-red-600 transition-colors">Violences intrafamiliales</span>
+      </button>
+    </div>
+  </div>
+
+  <!-- Informations complémentaires -->
+  <div class="mt-8 grid grid-cols-1 md:grid-cols-2 gap-6">
+    <!-- À propos -->
+    <div class="p-6 bg-blue-50 border border-blue-200 rounded-xl">
+      <div class="flex items-start space-x-3">
+        <div class="flex-shrink-0">
+          <svg class="w-6 h-6 text-blue-600 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+          </svg>
+        </div>
+        <div class="flex-1">
+          <h4 class="text-sm font-bold text-blue-900 mb-2">À propos des données</h4>
+          <p class="text-sm text-blue-800 leading-relaxed">
+            Les données présentées sont issues de sources officielles (INSEE, CAF, etc.).
+            Chaque section propose une analyse détaillée avec des visualisations interactives et des cartes.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Guide d'utilisation -->
+    <div class="p-6 bg-indigo-50 border border-indigo-200 rounded-xl">
+      <div class="flex items-start space-x-3">
+        <div class="flex-shrink-0">
+          <svg class="w-6 h-6 text-indigo-600 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"></path>
+          </svg>
+        </div>
+        <div class="flex-1">
+          <h4 class="text-sm font-bold text-indigo-900 mb-2">Guide d'utilisation</h4>
+          <p class="text-sm text-indigo-800 leading-relaxed">
+            Naviguez entre les onglets pour explorer les différentes thématiques.
+            Les graphiques sont interactifs : survolez-les pour plus de détails.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/app/views/epci_dashboard/index.html.erb
+++ b/app/views/epci_dashboard/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="min-h-screen bg-gradient-to-br from-indigo-50 via-white to-purple-50"
      data-controller="tabs"
-     data-tabs-default-tab-value="population"
+     data-tabs-default-tab-value="accueil"
      data-epci-code="<%= @epci_code %>"
      data-epci-name="<%= @epci_name %>">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -104,7 +104,7 @@
     </div>
 
     <!-- ✅ CONSERVÉ : Navigation par onglets avec design moderne -->
-    <div class="bg-white/60 backdrop-blur-sm rounded-2xl shadow-lg border border-white/30 mb-8 overflow-hidden">
+    <div id="tabs-navigation" class="bg-white/60 backdrop-blur-sm rounded-2xl shadow-lg border border-white/30 mb-8 overflow-hidden">
       <div class="p-2 relative">
         <!-- ✅ CONSERVÉ : Flèche gauche -->
         <button id="scroll-left"
@@ -127,6 +127,26 @@
         <div class="absolute right-0 top-0 bottom-0 w-12 bg-gradient-to-l from-white/60 to-transparent pointer-events-none z-5" id="gradient-right"></div>
 
         <nav class="flex space-x-1 overflow-x-auto scrollbar-hide scroll-smooth" id="tabs-container">
+
+          <!-- ✅ NOUVEL ONGLET ACCUEIL - EN PREMIÈRE POSITION -->
+          <button data-tabs-target="tab"
+                  data-action="click->tabs#switch"
+                  data-tab-id="accueil"
+                  class="group flex items-center px-4 py-3 rounded-xl font-medium text-sm transition-all duration-300 whitespace-nowrap min-w-fit hover:bg-white/50 text-gray-600 hover:text-gray-800">
+            <div class="flex items-center space-x-3">
+              <div class="p-2 rounded-lg bg-gradient-to-r from-blue-100 to-indigo-100 group-hover:from-blue-200 group-hover:to-indigo-200 transition-all duration-300">
+                <svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"></path>
+                </svg>
+              </div>
+              <div class="text-left">
+                <div class="font-semibold">Accueil</div>
+                <div class="text-xs text-gray-500">Vue d'ensemble</div>
+              </div>
+            </div>
+          </button>
+
+
           <!-- ✅ MODIFIÉ : Onglet Population avec indicateur de chargement -->
           <button data-tabs-target="tab"
                   data-action="click->tabs#switch"
@@ -293,7 +313,7 @@
               <div class="p-2 rounded-lg bg-gradient-to-r from-teal-100 to-cyan-100 group-hover:from-teal-200 group-hover:to-cyan-200 transition-all duration-300">
                 <svg class="w-5 h-5 text-teal-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7H4a2 2 0 00-2 2v10a2 2 0 002 2h16a2 2 0 002-2V9a2 2 0 00-2-2z"></path>
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7V5a2 2 0 00-2-2h-4a2 2 0 00-2-2v2"></path>
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2"></path>
                 </svg>
               </div>
               <div class="text-left">
@@ -315,11 +335,11 @@
               <div class="p-2 rounded-lg bg-gradient-to-r from-rose-100 to-pink-100 group-hover:from-rose-200 group-hover:to-pink-200 transition-all duration-300">
                 <svg class="w-5 h-5 text-rose-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <g stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
-                    <circle cx="15" cy="6" r="3"/>
-                    <path d="M15 9c-3 0-5 2-5 5v7h10v-7c0-3-2-5-5-5z"/>
-                    <rect x="4" y="14" width="10" height="6" rx="0.5" stroke-width="1.5"/>
-                    <path d="M3 20h12v1H3v-1z" stroke-width="1.5"/>
-                    <line x1="7" y1="17" x2="11" y2="17" stroke-width="1"/>
+                    <!-- Cercle de Vénus -->
+                    <circle cx="12" cy="9" r="5"/>
+                    <!-- Croix en bas -->
+                    <path d="M12 19v-5"/>
+                    <path d="M9 17h6"/>
                   </g>
                 </svg>
               </div>
@@ -359,6 +379,11 @@
 
     <!-- ✅ MODIFIÉ : Panneaux de contenu avec système asynchrone -->
     <div class="tab-content">
+
+    <!-- ✅ NOUVEAU : Panel Accueil - EN PREMIÈRE POSITION -->
+    <div data-tabs-target="panel" data-tab-id="accueil" class="hidden animate-fadeIn">
+      <%= render partial: 'epci_dashboard/accueil' %>
+    </div>
 
       <!-- 🚀 MODIFIÉ : Panel Population - Chargement asynchrone -->
       <div data-tabs-target="panel" data-tab-id="population" class="hidden animate-fadeIn">


### PR DESCRIPTION
- Add Accueil tab as first tab and default view
- Display key metrics: total population, commune count, EPCI code
- Quick navigation grid to all 10 dashboard sections
- Auto-scroll to tabs navigation on tab switch for better UX
- Always redirect to home tab on dashboard load (localStorage cleared)
- Load population data on initial page load for metrics display
- Harmonize icons between welcome page and navigation bar
- Clarify Capacite d'accueil label to avoid confusion with home tab

Users now always land on a welcoming overview page when accessing the EPCI dashboard.